### PR TITLE
Infra for more NDFC-like responses

### DIFF
--- a/app/models/fabric.py
+++ b/app/models/fabric.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # TODO: If SQLModel is ever fixed, remove the mypy directive below.
 # https://github.com/fastapi/sqlmodel/discussions/732
-# mypy: allow-call-arg
+# mypy: disable-error-code=call-arg
 import uuid
 from datetime import datetime
 from enum import Enum
@@ -68,6 +68,7 @@ class Fabric(FabricBase, table=True):
 
     Define the fabric table in the database.
     """
+
     id: uuid.UUID = Field(default_factory=uuid.uuid4)
     created_at: datetime | None = Field(default_factory=get_datetime)
 

--- a/app/models/fabric.py
+++ b/app/models/fabric.py
@@ -2,7 +2,6 @@
 import uuid
 from datetime import datetime
 from enum import Enum
-from typing import Optional
 
 from sqlmodel import Field, SQLModel
 
@@ -48,15 +47,15 @@ class FabricBase(SQLModel):
     Base class for all other fabric classes.
     """
 
-    FABRIC_NAME: Optional[str] = Field(default="BAD_FABRIC", primary_key=True)
+    FABRIC_NAME: str | None = Field(default=None, primary_key=True)
     BGP_AS: str = Field(index=True)
     REPLICATION_MODE: ReplicationModeEnum = Field(default="Multicast")
     FF: FFEnum = Field(default="Easy_Fabric")
 
     id: uuid.UUID = Field(default_factory=uuid.uuid4)
-    created_at: Optional[datetime] = Field(default_factory=get_datetime)
+    created_at: datetime | None = Field(default_factory=get_datetime)
 
-    updated_at: Optional[datetime] = Field(
+    updated_at: datetime | None = Field(
         default_factory=get_datetime,
         sa_column_kwargs={"onupdate": get_datetime},
     )
@@ -95,7 +94,7 @@ class FabricUpdate(SQLModel):
     Used to validate PUT requests.
     """
 
-    FABRIC_NAME: Optional[str] = None
-    BGP_AS: Optional[str] = None
-    REPLICATION_MODE: Optional[str] = None
-    FF: Optional[str] = None
+    FABRIC_NAME: str | None = None
+    BGP_AS: str | None = None
+    REPLICATION_MODE: str | None = None
+    FF: str | None = None

--- a/app/models/fabric.py
+++ b/app/models/fabric.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python
+# TODO: If SQLModel is ever fixed, remove the mypy directive below.
+# https://github.com/fastapi/sqlmodel/discussions/732
+# mypy: allow-call-arg
 import uuid
 from datetime import datetime
 from enum import Enum
@@ -65,7 +68,6 @@ class Fabric(FabricBase, table=True):
 
     Define the fabric table in the database.
     """
-
     id: uuid.UUID = Field(default_factory=uuid.uuid4)
     created_at: datetime | None = Field(default_factory=get_datetime)
 

--- a/app/models/fabric.py
+++ b/app/models/fabric.py
@@ -3,6 +3,7 @@ import uuid
 from datetime import datetime
 from enum import Enum
 
+from pydantic import BaseModel
 from sqlmodel import Field, SQLModel
 
 from .common import get_datetime
@@ -36,8 +37,13 @@ class NvPairs(SQLModel):
     Not currently used
     """
 
-    REPLICATION_MODE: ReplicationModeEnum
     BGP_AS: str
+    FABRIC_NAME: str
+    FF: str
+    REPLICATION_MODE: str
+    # id: uuid.UUID | None
+    # created_at: datetime | None
+    # updated_at: datetime | None
 
 
 class FabricBase(SQLModel):
@@ -47,10 +53,18 @@ class FabricBase(SQLModel):
     Base class for all other fabric classes.
     """
 
-    FABRIC_NAME: str | None = Field(default=None, primary_key=True)
     BGP_AS: str = Field(index=True)
-    REPLICATION_MODE: ReplicationModeEnum = Field(default="Multicast")
+    FABRIC_NAME: str | None = Field(default=None, primary_key=True)
     FF: FFEnum = Field(default="Easy_Fabric")
+    REPLICATION_MODE: ReplicationModeEnum | None = Field(default="Multicast")
+
+
+class Fabric(FabricBase, table=True):
+    """
+    # Summary
+
+    Define the fabric table in the database.
+    """
 
     id: uuid.UUID = Field(default_factory=uuid.uuid4)
     created_at: datetime | None = Field(default_factory=get_datetime)
@@ -61,14 +75,6 @@ class FabricBase(SQLModel):
     )
 
 
-class Fabric(FabricBase, table=True):
-    """
-    # Summary
-
-    Import to pick up all FabricBase behaviors.
-    """
-
-
 class FabricCreate(FabricBase):
     """
     # Summary
@@ -77,14 +83,15 @@ class FabricCreate(FabricBase):
     """
 
 
-class FabricPublic(FabricBase):
+class FabricResponseModel(BaseModel):
     """
     # Summary
 
-    Returned to clients.
+    Describes what is returned to clients.
     """
 
     id: uuid.UUID
+    nvPairs: NvPairs
 
 
 class FabricUpdate(SQLModel):


### PR DESCRIPTION
# Summary

This PR lays to groundwork for generating responses that are closer to what NDFC provides.

## Description

Added some functions and changed models to better mimic NDFC responses.


1. `app/endpoints/fabric.py`

- `build_response()`

New method to build client responses.

- `build_nv_pairs()`

New method to construct the nvPairs object in client responses.

2. `app/models/fabric.py`

- `FabricResponseModel()`

New class which determines the structure of the response sent to clients.  For now, we've added `id` (as a uuid.UUID) and `nvPairs`.

- `NvPairs()`

New class which determines the structure of the `nvPairs` object in a fabric response.
