### PR TITLE
Add models and endpoint handlers for fabric creation and login

### DIFF
--- a/app/endpoints/login.py
+++ b/app/endpoints/login.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+import copy
+import json
+
+from ..app import app
+from ..models.login import LoginResponseModel
+
+
+def build_rbac():
+    """
+    # Summary
+
+    Build the RBAC portion of the response
+    """
+    rbac = {}
+    rbac["domain"] = "local"
+    rbac["rolesR"] = 16777216
+    rbac["rolesW"] = 1
+    rbac["roles"] = []
+    rbac["roles"].append(["admin", "WritePriv"])
+    rbac["roles"].append(["app-user", "ReadPriv"])
+    return rbac
+
+
+def build_response():
+    """
+    # Summary
+
+    Build a login response that aligns with LoginResponseModel
+
+    ## Notes
+
+    1. If LoginResponseModel is changed, this function must also be updated
+    """
+    response = {}
+    response["jwttoken"] = "asdlfkjasdf"
+    response["username"] = "admin"
+    response["usertype"] = "local"
+    response["rbac"] = [build_rbac()]
+    response["statusCode"] = 200
+    response["token"] = "asdlfkjasdf"
+    return copy.deepcopy(response)
+
+
+@app.post(
+    "/login",
+    response_model=LoginResponseModel,
+)
+def post_login():
+    """
+    # Summary
+
+    POST request handler
+    """
+    response = build_response()
+    print(f"post_login: {json.dumps(response, indent=4, sort_keys=True)}")
+    return response

--- a/app/endpoints/v1_configtemplate_easy_fabric.py
+++ b/app/endpoints/v1_configtemplate_easy_fabric.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python
+import copy
+import json
+
+from ..app import app
+from ..models.v1_configtemplate_easy_fabric import V1ConfigtemplateEasyFabricResponseModel
+
+
+def build_bgp_as():
+    """
+    # Summary
+
+    Build the template BGP_AS object
+    """
+    d = {}
+    d["name"] = "BGP_AS"
+    d["description"] = None
+    d["parameterType"] = "string"
+    d["metaProperties"] = {}
+    d["metaProperties"]["minLength"] = "1"
+    d["metaProperties"]["minLength"] = "11"
+    regularExpr = "^(((\\+)?[1-9]{1}[0-9]{0,8}|(\\+)?[1-3]{1}[0-9]{1,9}"
+    regularExpr += "|(\\+)?[4]{1}([0-1]{1}[0-9]{8}|[2]{1}([0-8]{1}[0-9]{7}|"
+    regularExpr += "[9]{1}([0-3]{1}[0-9]{6}|[4]{1}([0-8]{1}[0-9]{5}"
+    regularExpr += "|[9]{1}([0-5]{1}[0-9]{4}|[6]{1}([0-6]{1}[0-9]{3}"
+    regularExpr += "|[7]{1}([0-1]{1}[0-9]{2}|[2]{1}([0-8]{1}[0-9]{1}"
+    regularExpr += "|[9]{1}[0-5]{1})))))))))|([1-5]\\d{4}|[1-9]\\d{0,3}"
+    regularExpr += "|6[0-4]\\d{3}|65[0-4]\\d{2}|655[0-2]\\d|6553[0-5])"
+    regularExpr += "(\\.([1-5]\\d{4}|[1-9]\\d{0,3}|6[0-4]\\d{3}|65[0-4]\\d{2}|"
+    regularExpr += "655[0-2]\\d|6553[0-5]|0))?)$"
+    d["metaProperties"]["regularExpr"] = regularExpr
+    d["annotations"] = {}
+    d["annotations"]["DisplayName"] = "BGP ASN"
+    d["annotations"]["Description"] = "1-4294967295 | 1-65535[.0-65535]<br />It is a good practice to have a unique ASN for each Fabric."
+    d["annotations"]["IsAsn"] = True
+    d["annotations"]["IsMandatory"] = True
+    d["structureParameters"] = {}
+    d["parameterTypeStructure"] = False
+    d["defaultValue"] = None
+    d["optional"] = False
+    return copy.deepcopy(d)
+
+
+def build_fabric_name():
+    """
+    # Summary
+
+    Build the template FABRIC_NAME object
+    """
+    d = {}
+    d["name"] = "FABRIC_NAME"
+    d["description"] = None
+    d["parameterType"] = "string"
+    d["metaProperties"] = {}
+    d["metaProperties"]["minLength"] = "1"
+    d["metaProperties"]["minLength"] = "32"
+    d["annotations"] = {}
+    d["annotations"]["DisplayName"] = "Fabric Name"
+    d["annotations"]["Description"] = "Please provide the fabric name to create it (Max Size 32)"
+    d["annotations"]["IsMandatory"] = True
+    d["annotations"]["IsFabricName"] = True
+    d["structureParameters"] = {}
+    d["parameterTypeStructure"] = False
+    d["defaultValue"] = None
+    d["optional"] = False
+    return copy.deepcopy(d)
+
+
+def build_fabric_type():
+    """
+    # Summary
+
+    Build the template FABRIC_TYPE object
+    """
+    d = {}
+    d["name"] = "FABRIC_TYPE"
+    d["description"] = None
+    d["parameterType"] = "string"
+    d["metaProperties"] = {}
+    d["metaProperties"]["defaultValue"] = "Switch_Fabric"
+    d["annotations"] = {}
+    d["annotations"]["ReadOnly"] = True
+    d["annotations"]["DisplayName"] = "Fabric Type"
+    d["annotations"]["IsFabricType"] = True
+    d["annotations"]["IsMandatory"] = True
+    d["annotations"]["Section"] = '"Hidden"'
+    d["structureParameters"] = {}
+    d["parameterTypeStructure"] = False
+    d["defaultValue"] = None
+    d["optional"] = False
+    return copy.deepcopy(d)
+
+
+def build_replication_mode():
+    """
+    # Summary
+
+    Build the template REPLICATION_MODE object
+    """
+    d = {}
+    d["name"] = "REPLICATION_MODE"
+    d["description"] = None
+    d["parameterType"] = "string"
+    d["metaProperties"] = {}
+    d["metaProperties"]["defaultValue"] = "Multicast"
+    d["annotations"] = {}
+    d["annotations"]["Enum"] = "Multicast,Ingress"
+    d["annotations"]["Description"] = "Replication Mode for BUM Traffic"
+    d["annotations"]["IsMandatory"] = True
+    d["annotations"]["DisplayName"] = "Replication Mode"
+    d["annotations"]["IsShow"] = '"UNDERLAY_IS_V6!=true"'
+    d["annotations"]["IsReplicationMode"] = True
+    d["annotations"]["Section"] = '"Replication"'
+    d["structureParameters"] = {}
+    d["parameterTypeStructure"] = False
+    d["defaultValue"] = None
+    d["optional"] = False
+    return copy.deepcopy(d)
+
+
+def build_response():
+    """
+    # Summary
+
+    Build a response that aligns with the ResponseModel
+
+    ## Notes
+
+    1. If V1FmAboutVersionResponseModel is changed, this function must also be updated
+    """
+    response = {}
+    response["instanceClassId"] = 1000
+    response["assignedInstanceClassId"] = 0
+    response["instanceName"] = "com.cisco.dcbu.dcm.model.cfgtemplate.ConfigTemplate:name=Easy_Fabric:type=true"
+    response["name"] = "Easy_Fabric"
+    response["description"] = "Fabric for a VXLAN EVPN deployment with Nexus 9000 and 3000 switches."
+    response["userDefined"] = True
+    response["parameters"] = []
+    response["parameters"].append(build_bgp_as())
+    response["parameters"].append(build_fabric_name())
+    response["parameters"].append(build_fabric_type())
+    response["parameters"].append(build_replication_mode())
+    response["content"] = "##template ..."
+    return copy.deepcopy(response)
+
+
+@app.get(
+    "/appcenter/cisco/ndfc/api/v1/configtemplate/rest/config/templates/Easy_Fabric",
+    response_model=V1ConfigtemplateEasyFabricResponseModel,
+)
+def get_v1_configtemplate_easy_fabric():
+    """
+    # Summary
+
+    GET request handler.
+    """
+    response = build_response()
+    print(f"get_v1_configtemplate_easy_fabric: response: {json.dumps(response, indent=4, sort_keys=True)}")
+    return response

--- a/app/endpoints/v1_fm_about_version.py
+++ b/app/endpoints/v1_fm_about_version.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+import copy
+import json
+import uuid
+
+from ..app import app
+from ..models.v1_fm_about_version import V1FmAboutVersionResponseModel
+
+
+def build_response():
+    """
+    # Summary
+
+    Build a response that aligns with the ResponseModel
+
+    ## Notes
+
+    1. If V1FmAboutVersionResponseModel is changed, this function must also be updated
+    """
+    response = {}
+    response["version"] = "12.1.2e"
+    response["mode"] = "LAN"
+    response["isMediaController"] = False
+    response["dev"] = False
+    response["isHaEnabled"] = False
+    response["install"] = "EASYFABRIC"
+    response["uuid"] = f"{uuid.uuid4()}"
+    response["is_upgrade_inprogress"] = False
+    return copy.deepcopy(response)
+
+
+@app.get(
+    "/appcenter/cisco/ndfc/api/v1/fm/about/version",
+    response_model=V1FmAboutVersionResponseModel,
+)
+def get_v1_fm_about_version():
+    """
+    # Summary
+
+    GET request handler.
+    """
+    response = build_response()
+    print(f"v1_fm_about_version: response: {json.dumps(response, indent=4, sort_keys=True)}")
+    return response

--- a/app/endpoints/v1_fm_features.py
+++ b/app/endpoints/v1_fm_features.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python
+import copy
+import json
+
+from ..app import app
+from ..models.v1_fm_features import V1FmFeaturesResponseModel
+
+
+def build_change_mgmt():
+    """
+    # Summary
+
+    Build the response change-mgmt object
+    """
+    d = {}
+    d["name"] = "Change Control"
+    d["description"] = "Tracking, Approval, and Rollback of all Configuration Changes"
+    d["ui"] = False
+    d["predisablecheck"] = "https://dcnm-lan-fabric.cisco-ndfc.svc:9443/rest/chngmgmt/preDisableCheck"
+    d["spec"] = ""
+    d["admin_state"] = "disabled"
+    d["oper_state"] = ""
+    d["kind"] = "featurette"
+    d["featureset"] = {}
+    d["featureset"]["lan"] = {}
+    d["featureset"]["lan"]["default"] = False
+    return copy.deepcopy(d)
+
+
+def build_cvisualizer():
+    """
+    # Summary
+
+    Build the response cvisualizer object
+    """
+    d = {}
+    d["name"] = "Kubernetes Visualizer"
+    d["description"] = "Network Visualization of K8s Clusters"
+    d["ui"] = False
+    d["spec"] = ""
+    d["admin_state"] = "disabled"
+    d["oper_state"] = ""
+    d["kind"] = "feature"
+    d["featureset"] = {}
+    d["featureset"]["lan"] = {}
+    d["featureset"]["lan"]["default"] = False
+    return copy.deepcopy(d)
+
+
+def build_elasticservice():
+    """
+    # Summary
+
+    Build the response elasticservice object
+    """
+    d = {}
+    d["name"] = "L4-L7 Services"
+    d["description"] = "L4-L7 Services"
+    d["ui"] = True
+    d["hidden"] = True
+    d["spec"] = ""
+    d["admin_state"] = "enabled"
+    d["oper_state"] = "started"
+    d["installed"] = "2024-02-05 19:12:57.098455128 +0000 UTC"
+    d["kind"] = "feature"
+    d["featureset"] = {}
+    d["featureset"]["lan"] = {}
+    d["featureset"]["lan"]["default"] = True
+    return copy.deepcopy(d)
+
+
+def build_apidoc():
+    """
+    # Summary
+
+    Build the response apidoc object
+    """
+    d = {}
+    d["url"] = "https://dcnm-elasticservice.cisco-ndfc.svc:9443/v3/api-docs"
+    d["subpath"] = "elastic-service"
+    d["schema"] = None
+    return copy.deepcopy(d)
+
+
+def build_vxlan():
+    """
+    # Summary
+
+    Build the response vxlan object
+    """
+    d = {}
+    d["name"] = "Fabric Builder"
+    d["description"] = "Automation, Compliance, and Management for NX-OS and Other devices"
+    d["ui"] = False
+    d["predisablecheck"] = "https://dcnm-lan-fabric.cisco-ndfc.svc:9443/rest/control/fabrics/lanVXLANPreDisableCheck"
+    d["spec"] = ""
+    d["admin_state"] = "enabled"
+    d["oper_state"] = "started"
+    d["kind"] = "feature"
+    d["featureset"] = {}
+    d["featureset"]["lan"] = {}
+    d["featureset"]["lan"]["default"] = True
+    d["apidoc"] = []
+    apidoc = {}
+    apidoc["url"] = "https://sgm.cisco-ndfc.svc:9443/api-docs"
+    apidoc["subpath"] = ""
+    apidoc["schema"] = None
+    d["apidoc"].append(apidoc)
+    return copy.deepcopy(d)
+
+
+def build_response():
+    """
+    # Summary
+
+    Build a response that aligns with the ResponseModel
+
+    ## Notes
+
+    1. If V1FmAboutVersionResponseModel is changed, this function must also be updated
+    """
+    response = {}
+    response["status"] = "success"
+    response["data"] = {}
+    response["data"]["name"] = ""
+    response["data"]["version"] = 201
+    response["data"]["features"] = {}
+    response["data"]["features"]["change-mgmt"] = build_change_mgmt()
+    response["data"]["features"]["cvisualizer"] = build_cvisualizer()
+    response["data"]["features"]["elasticservice"] = build_elasticservice()
+    response["data"]["features"]["apidoc"] = build_apidoc()
+    response["data"]["features"]["vxlan"] = build_vxlan()
+
+    return copy.deepcopy(response)
+
+
+@app.get(
+    "/appcenter/cisco/ndfc/api/v1/fm/features",
+    response_model=V1FmFeaturesResponseModel,
+)
+def get_v1_fm_features():
+    """
+    # Summary
+
+    GET request handler.
+    """
+    response = build_response()
+    print(f"v1_fm_features: response: {json.dumps(response, indent=4, sort_keys=True)}")
+    return response

--- a/app/main.py
+++ b/app/main.py
@@ -3,6 +3,10 @@
 from .app import app
 from .db import create_db_and_tables
 from .endpoints.fabric import delete_fabric, get_fabric_by_fabric_name, get_fabrics, post_fabric, put_fabric
+from .endpoints.login import post_login
+from .endpoints.v1_configtemplate_easy_fabric import get_v1_configtemplate_easy_fabric
+from .endpoints.v1_fm_about_version import get_v1_fm_about_version
+from .endpoints.v1_fm_features import get_v1_fm_features
 
 
 @app.on_event("startup")

--- a/app/models/login.py
+++ b/app/models/login.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+# TODO: If SQLModel is ever fixed, remove the mypy directive below.
+# https://github.com/fastapi/sqlmodel/discussions/732
+# mypy: disable-error-code=call-arg
+from typing import Any, List
+
+from pydantic import BaseModel
+from sqlmodel import Field
+
+
+class LoginRBAC(BaseModel):
+    """
+    # Summary
+
+    Validator for the RBAC portion of the login response.
+    """
+
+    domain: str = Field(default="all")
+    rolesR: int = Field(default=16777216)
+    rolesW: int = Field(default=1)
+    roles: List[List[Any]]
+
+
+class LoginResponseModel(BaseModel):
+    """
+    # Summary
+
+    Describes what is returned to clients.
+    """
+
+    jwttoken: str
+    username: str
+    usertype: str
+    rbac: List[LoginRBAC]
+    statusCode: int
+    token: str

--- a/app/models/v1_configtemplate_easy_fabric.py
+++ b/app/models/v1_configtemplate_easy_fabric.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+# TODO: If SQLModel is ever fixed, remove the mypy directive below.
+# https://github.com/fastapi/sqlmodel/discussions/732
+# mypy: disable-error-code=call-arg
+
+from typing import Dict, List
+
+from pydantic import BaseModel
+from sqlmodel import Field
+
+
+class V1ConfigtemplateEasyFabricBase(BaseModel):
+    """
+    # Summary
+
+    Base class for all other classes in this file.
+    """
+
+    instanceClassId: int = Field(default=1000)
+    assignedInstanceClassId: int = Field(default=0)
+    instanceName: str = Field(default="com.cisco.dcbu.dcm.model.cfgtemplate.ConfigTemplate:name=Easy_Fabric:type=true")
+    name: str = Field(default="Easy_Fabric")
+    description: str = Field(default="Fabric for a VXLAN EVPN deployment with Nexus 9000 and 3000 switches.")
+    userDefined: bool = Field(default=True)
+    parameters: List[Dict]
+    content: str
+
+
+class V1ConfigtemplateEasyFabricResponseModel(V1ConfigtemplateEasyFabricBase):
+    """
+    # Summary
+
+    Describes what is returned to clients.
+    """

--- a/app/models/v1_fm_about_version.py
+++ b/app/models/v1_fm_about_version.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+# TODO: If SQLModel is ever fixed, remove the mypy directive below.
+# https://github.com/fastapi/sqlmodel/discussions/732
+# mypy: disable-error-code=call-arg
+import uuid
+
+from pydantic import BaseModel
+from sqlmodel import Field
+
+
+class V1FmAboutVersionBase(BaseModel):
+    """
+    # Summary
+
+    Base class for all other classes in this file.
+    """
+
+    version: str = Field()
+    mode: str | None = Field(default="LAN")
+    isMediaController: bool = Field(default=True)
+    dev: bool = Field(default=False)
+    isHaEnabled: bool = Field(default=False)
+    install: str = Field(default="EASYFABRIC")
+    uuid: str = Field(default_factory=uuid.uuid4, primary_key=True)
+    is_upgrade_inprogress: bool = Field(default=False)
+
+
+class V1FmAboutVersionResponseModel(V1FmAboutVersionBase):
+    """
+    # Summary
+
+    Describes what is returned to clients.
+    """

--- a/app/models/v1_fm_features.py
+++ b/app/models/v1_fm_features.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+# TODO: If SQLModel is ever fixed, remove the mypy directive below.
+# https://github.com/fastapi/sqlmodel/discussions/732
+# mypy: disable-error-code=call-arg
+
+from pydantic import BaseModel
+from sqlmodel import Field
+
+
+class V1FmFeaturesBase(BaseModel):
+    """
+    # Summary
+
+    Base class for all other classes in this file.
+    """
+
+    status: str = Field(default="success")
+    data: dict
+
+
+class V1FmFeaturesResponseModel(V1FmFeaturesBase):
+    """
+    # Summary
+
+    Describes what is returned to clients.
+    """


### PR DESCRIPTION
Add models and endpoint handlers required for the dcnm-ansible dcnm_fabric module to succussfully run a basic merged-state playbook against the mock controller.

1. app/endpoints additions

- login.py
- v1_configtemplate_easy_fabric.py
- v1_fm_about_version.py
- v1_fm_featuers.py

2. app/models additions

- login.py
- v1_configtemplate_easy_fabric.py
- v1_fm_about_version.py
- v1_fm_featuers.py

3. app/main.py

Update imports to include the above endpoints