### PR TITLE
Convert v1 fabric id from uuid to int

### DIFF
--- a/app/v1/endpoints/fabric.py
+++ b/app/v1/endpoints/fabric.py
@@ -52,11 +52,15 @@ def v1_delete_fabric(*, session: Session = Depends(get_session), fabric_name: st
         "path": "/rest/control/fabrics/f2"
     }
     """
-    fabric = session.get(Fabric, fabric_name)
-    if not fabric:
-        detail = {"timestamp": int(datetime.datetime.now().timestamp()), "status": 404, "error": "Not Found", "path": f"/rest/control/fabrics/{fabric_name}"}
+    db_fabric = session.exec(select(Fabric).where(Fabric.FABRIC_NAME == fabric_name)).first()
+    if not db_fabric:
+        detail = {}
+        detail["timestamp"] = int(datetime.datetime.now().timestamp())
+        detail["status"] = 404
+        detail["error"] = "Not Found"
+        detail["path"] = f"/rest/control/fabrics/{fabric_name}"
         raise HTTPException(status_code=404, detail=detail)
-    session.delete(fabric)
+    session.delete(db_fabric)
     session.commit()
     return {f"Fabric '{fabric_name}' is deleted successfully!"}
 
@@ -95,10 +99,10 @@ def v1_get_fabric_by_fabric_name(*, session: Session = Depends(get_session), fab
 
     GET request handler with fabric_name as path parameter.
     """
-    fabric = session.get(Fabric, fabric_name)
-    if not fabric:
+    db_fabric = session.exec(select(Fabric).where(Fabric.FABRIC_NAME == fabric_name)).first()
+    if not db_fabric:
         raise HTTPException(status_code=404, detail=f"Fabric {fabric_name} not found")
-    response = build_response(fabric)
+    response = build_response(db_fabric)
     return response
 
 
@@ -150,7 +154,7 @@ def v1_put_fabric(
 
     PUT request handler
     """
-    db_fabric = session.get(Fabric, fabric_name)
+    db_fabric = session.exec(select(Fabric).where(Fabric.FABRIC_NAME == fabric_name)).first()
     if not db_fabric:
         raise HTTPException(status_code=404, detail=f"Fabric {fabric_name} not found")
     fabric_data = fabric.model_dump(exclude_unset=True)

--- a/app/v1/models/fabric.py
+++ b/app/v1/models/fabric.py
@@ -2,7 +2,6 @@
 # TODO: If SQLModel is ever fixed, remove the mypy directive below.
 # https://github.com/fastapi/sqlmodel/discussions/732
 # mypy: disable-error-code=call-arg
-import uuid
 from datetime import datetime
 from enum import Enum
 
@@ -1428,7 +1427,7 @@ class FabricBase(SQLModel):
     EXTRA_CONF_TOR: str | None = Field(default=None, description=Descriptions().extra_conf_tor)
 
     FABRIC_INTERFACE_TYPE: FabricInterfaceTypeEnum | None = Field(default=FabricInterfaceTypeEnum.p2p, description=Descriptions().fabric_interface_type)
-    FABRIC_NAME: str | None = Field(default=None, primary_key=True, min_length=1, max_length=32, description=Descriptions().fabric_name)
+    FABRIC_NAME: str | None = Field(default=None, unique=True, index=True, min_length=1, max_length=32, description=Descriptions().fabric_name)
     FABRIC_MTU: int | None = Field(default=9216, ge=576, le=9216, description=Descriptions().fabric_mtu)
     FABRIC_MTU_PREV: int | None = Field(default=9216, ge=576, le=9216)
     FABRIC_TYPE: str | None = Field(default="Switch_Fabric")
@@ -1612,7 +1611,7 @@ class Fabric(FabricBase, table=True):
     Define the fabric table in the database.
     """
 
-    id: uuid.UUID = Field(default_factory=uuid.uuid4)
+    id: int | None = Field(default=None, primary_key=True)
     created_at: datetime | None = Field(default_factory=get_datetime)
 
     updated_at: datetime | None = Field(
@@ -1648,7 +1647,7 @@ class FabricResponseModel(BaseModel):
     Describes what is returned to clients.
     """
 
-    id: uuid.UUID
+    id: int
     nvPairs: NvPairs
 
 


### PR DESCRIPTION
NDFC 3.2.1e uses an int for fabric ID.  This commit aligns ndfc_mock with that.

Previously we were using uuid.uuid64 as the fabric id, which was generated locally, and were using FABRIC_NAME as the primary key.  In order to get SQLite to auto-increment the id, we need to make id the primary key.  We then set a unique constraint on FABRIC_NAME and set index=True for faster retrieval.

# 1. app/endpoints/fabric.py

Modified all endpoints that previously used session.get() to instead use session.exec(select...) to query for the fabric_name.

- v1_get_fabric_by_fabric_name
- v1_delete_fabric
- v1_put_fabric

# 2. app/v1/models/fabric.py

##  Removed uuid import

## FabricBase()

- Changed FABRIC_NAME Field() definition to remove primary_key=True and add unique=True and index=True

## Fabric()

- Changed id type from uuid.UUID to int and modified its Field() definition to remove default_factory=uuid.uuid64 and add default=None and primary_key=True.

## FabricResponseModel()

- Changed id type to int.