### PR TITLE
Inventory (part 1)

### DIFF
--- a/app/common/enums/switch.py
+++ b/app/common/enums/switch.py
@@ -1,7 +1,7 @@
 from enum import Enum
 
 
-class platform(Enum):
+class PlatformEnum(Enum):
     """
     Choices for switch platform
     """
@@ -10,7 +10,7 @@ class platform(Enum):
     nxos: str = "nx-os"
 
 
-class switchConfigSyncStatus(Enum):
+class SwitchConfigSyncStatusEnum(Enum):
     """
     Choices for switch configuration sync status
     """
@@ -21,7 +21,7 @@ class switchConfigSyncStatus(Enum):
     notApplicable: str = "notApplicable"
 
 
-class SwitchRole(Enum):
+class SwitchRoleEnum(Enum):
     """
     Choices for switch role
     """
@@ -43,7 +43,38 @@ class SwitchRole(Enum):
     tor: str = "tor"
 
 
-class vpcRole(Enum):
+class SwitchRoleFriendlyEnum(Enum):
+    """
+    Switch role friendly names
+    """
+
+    access: str = "access"
+    aggregation: str = "aggregation"
+    border: str = "border"
+    borderGateway: str = "border gateway"
+    borderGatewaySpine: str = "border gateway spine"
+    borderGatewaySuperSpine: str = "border gateway super spine"
+    borderSpine: str = "border spine"
+    borderSuperSpine: str = "border super spine"
+    coreRouter: str = "core router"
+    edgeRouter: str = "edge router"
+    leaf: str = "leaf"
+    spine: str = "spine"
+    superSpine: str = "super spine"
+    tier2Leaf: str = "tier2 leaf"
+    tor: str = "tor"
+
+
+class SwitchUnmanageableCauseEnum(Enum):
+    """
+    Choices for unmanageableCause field in Switch model.
+    """
+
+    none = ""
+    Unreachable = "Unreachable"
+
+
+class VpcRoleEnum(Enum):
     """
     Choices for vpc role
     """

--- a/app/main.py
+++ b/app/main.py
@@ -6,6 +6,7 @@ from .v1.endpoints.fabric import v1_delete_fabric, v1_get_fabric_by_fabric_name,
 from .v1.endpoints.fm_about_version import get_v1_fm_about_version
 from .v1.endpoints.fm_features import get_v1_fm_features
 from .v1.endpoints.inventory import v1_get_switches_by_fabric_name
-from .v1.endpoints.lan_fabric_rest_control_switches_overview import v1_lan_fabric_rest_control_switches_overview_by_fabric_name
+from .v1.endpoints.lan_fabric.rest_control_switches_fabric_name import v1_get_fabric_name_by_switch_serial_number
+from .v1.endpoints.lan_fabric.rest_control_switches_overview import v1_lan_fabric_rest_control_switches_overview_by_fabric_name
 from .v1.endpoints.login import post_login
 from .v2.endpoints.fabric import v2_delete_fabric, v2_get_fabric_by_fabric_name, v2_get_fabrics, v2_post_fabric, v2_put_fabric

--- a/app/main.py
+++ b/app/main.py
@@ -5,6 +5,7 @@ from .v1.endpoints.configtemplate import get_v1_configtemplate_by_name
 from .v1.endpoints.fabric import v1_delete_fabric, v1_get_fabric_by_fabric_name, v1_get_fabrics, v1_post_fabric, v1_put_fabric
 from .v1.endpoints.fm_about_version import get_v1_fm_about_version
 from .v1.endpoints.fm_features import get_v1_fm_features
+from .v1.endpoints.inventory import v1_get_switches_by_fabric_name
 from .v1.endpoints.lan_fabric_rest_control_switches_overview import v1_lan_fabric_rest_control_switches_overview_by_fabric_name
 from .v1.endpoints.login import post_login
 from .v2.endpoints.fabric import v2_delete_fabric, v2_get_fabric_by_fabric_name, v2_get_fabrics, v2_post_fabric, v2_put_fabric

--- a/app/v1/endpoints/inventory.py
+++ b/app/v1/endpoints/inventory.py
@@ -1,0 +1,343 @@
+#!/usr/bin/env python
+import copy
+import datetime
+from typing import List
+
+from fastapi import Depends, HTTPException
+from sqlmodel import Session, select
+
+from ...app import app
+from ...db import get_session
+from ..models.fabric import Fabric
+from ..models.inventory import SwitchDbModel, SwitchDiscoverBodyModel, SwitchDiscoverItem, SwitchResponseModel
+
+
+def build_response_switch(db_switch: SwitchDbModel) -> SwitchResponseModel:
+    """
+    # Summary
+
+    Build a SwitchResponseModel object from a SwitchDbModel object.
+    """
+    return SwitchResponseModel(
+        activeSupSlot=db_switch.activeSupSlot,
+        availPorts=db_switch.availPorts,
+        ccStatus=db_switch.ccStatus,
+        cfsSyslogStatus=db_switch.cfsSyslogStatus,
+        colDBId=db_switch.colDBId,
+        connUnitStatus=db_switch.connUnitStatus,
+        consistencyState=db_switch.consistencyState,
+        contact=db_switch.contact,
+        cpuUsage=db_switch.cpuUsage,
+        deviceType=db_switch.deviceType,
+        displayHdrs=db_switch.displayHdrs,
+        displayValues=db_switch.displayValues,
+        domain=db_switch.domain,
+        domainID=db_switch.domainID,
+        elementType=db_switch.elementType,
+        fabricId=db_switch.fabricId,
+        fabricName=db_switch.fabricName,
+        fabricTechnology=db_switch.fabricTechnology,
+        fcoeEnabled=db_switch.fcoeEnabled,
+        fex=db_switch.fex,
+        fexMap={},
+        fid=db_switch.fid,
+        freezeMode=db_switch.freezeMode,
+        health=db_switch.health,
+        hostName=db_switch.hostName,
+        index=db_switch.index,
+        intentedpeerName=db_switch.intentedpeerName,
+        interfaces=db_switch.interfaces,
+        ipAddress=db_switch.ipAddress,
+        ipDomain=db_switch.ipDomain,
+        isEchSupport=db_switch.isEchSupport,
+        isLan=db_switch.isLan,
+        isNonNexus=db_switch.isNonNexus,
+        isPmCollect=db_switch.isPmCollect,
+        isSharedBorder=db_switch.isSharedBorder,
+        isTrapDelayed=db_switch.isTrapDelayed,
+        isVpcConfigured=db_switch.isVpcConfigured,
+        is_smlic_enabled=db_switch.is_smlic_enabled,
+        keepAliveState=db_switch.keepAliveState,
+        lastScanTime=db_switch.lastScanTime,
+        licenseDetail=db_switch.licenseDetail,
+        licenseViolation=db_switch.licenseViolation,
+        linkName=db_switch.linkName,
+        location=db_switch.location,
+        logicalName=db_switch.logicalName,
+        managable=db_switch.managable,
+        mds=db_switch.mds,
+        membership=db_switch.membership,
+        memoryUsage=db_switch.memoryUsage,
+        mgmtAddress=db_switch.mgmtAddress,
+        mode=db_switch.mode,
+        model=db_switch.model,
+        modelType=db_switch.modelType,
+        modules=db_switch.modules,
+        moduleIndexOffset=db_switch.moduleIndexOffset,
+        monitorMode=db_switch.monitorMode,
+        name=db_switch.name,
+        npvEnabled=db_switch.npvEnabled,
+        numberOfPorts=db_switch.numberOfPorts,
+        network=db_switch.network,
+        nonMdsModel=db_switch.nonMdsModel,
+        operMode=db_switch.operMode,
+        operStatus=db_switch.operStatus,
+        peer=db_switch.peer,
+        peerlinkState=db_switch.peerlinkState,
+        peerSerialNumber=db_switch.peerSerialNumber,
+        peerSwitchDbId=db_switch.peerSwitchDbId,
+        ports=db_switch.ports,
+        present=db_switch.present,
+        primaryIP=db_switch.primaryIP,
+        primarySwitchDbID=db_switch.primarySwitchDbID,
+        principal=db_switch.principal,
+        protoDiscSettings=db_switch.protoDiscSettings,
+        recvIntf=db_switch.recvIntf,
+        release=db_switch.release,
+        role=db_switch.role,
+        sanAnalyticsCapable=db_switch.sanAnalyticsCapable,
+        scope=db_switch.scope,
+        secondaryIP=db_switch.secondaryIP,
+        secondarySwitchDbID=db_switch.secondarySwitchDbID,
+        sendIntf=db_switch.sendIntf,
+        serialNumber=db_switch.serialNumber,
+        sharedBorder=db_switch.sharedBorder,
+        sourceInterface=db_switch.sourceInterface,
+        sourceVrf=db_switch.sourceVrf,
+        standbySupState=db_switch.standbySupState,
+        status=db_switch.status,
+        switchDbID=db_switch.switchDbID,
+        swType=db_switch.swType,
+        swUUID=db_switch.swUUID,
+        swUUIDId=db_switch.swUUIDId,
+        swWwn=db_switch.swWwn,
+        swWwnName=db_switch.swWwnName,
+        sysDescr=db_switch.sysDescr,
+        systemMode=db_switch.systemMode,
+        uid=db_switch.uid,
+        unmanagableCause=db_switch.unmanagableCause,
+        upTime=db_switch.upTime,
+        upTimeNumber=db_switch.upTimeNumber,
+        upTimeStr=db_switch.upTimeStr,
+        usedPorts=db_switch.usedPorts,
+        username=db_switch.username,
+        vdcId=db_switch.vdcId,
+        vdcName=db_switch.vdcName,
+        vdcMac=db_switch.vdcMac,
+        vendor=db_switch.vendor,
+        version=db_switch.version,
+        vpcDomain=db_switch.vpcDomain,
+        vrf=db_switch.vrf,
+        vsanWwn=db_switch.vsanWwn,
+        vsanWwnName=db_switch.vsanWwnName,
+        waitForSwitchModeChg=db_switch.waitForSwitchModeChg,
+        wwn=db_switch.wwn,
+    )
+
+
+def build_db_switch(switch: SwitchDiscoverItem, db_fabric: Fabric) -> SwitchDbModel:
+    """
+    # Summary
+
+    Given a  SwitchDiscoverBodyModel and a Fabric model,
+    return a populated SwitchDbModel object.
+    """
+    return SwitchDbModel(
+        activeSupSlot=1,
+        availPorts=48,
+        ccStatus="",
+        cfsSyslogStatus=0,
+        colDBId=0,
+        connUnitStatus=0,
+        consistencyState=True,
+        contact="",
+        cpuUsage=0,
+        deviceType="Switch_Fabric",
+        displayHdrs="",
+        displayValues="",
+        domain="",
+        domainID=0,
+        elementType="",
+        fabricId=db_fabric.id,
+        fabricName="",
+        fabricTechnology=db_fabric.FF,
+        fcoeEnabled=False,
+        fex=False,
+        fid=0,
+        freezeMode="",
+        health=0,
+        hostName=switch.sysName,
+        index=0,
+        intentedpeerName="",
+        interfaces="",
+        ipAddress=switch.ipaddr,
+        ipDomain="",
+        isEchSupport=False,
+        isLan=False,
+        isNonNexus=False,
+        isPmCollect=False,
+        isSharedBorder=False,
+        isTrapDelayed=False,
+        isVpcConfigured=False,
+        is_smlic_enabled=False,
+        keepAliveState="",
+        lastScanTime=0,
+        licenseDetail="",
+        licenseViolation=False,
+        linkName="",
+        logicalName=switch.sysName,
+        managable=True,
+        mds=False,
+        membership="",
+        mgmtAddress="",
+        memoryUsage=0,
+        mode="Normal",
+        model="",
+        moduleIndexOffset=9999,
+        modelType=0,
+        name=switch.sysName,
+        npvEnabled=False,
+        numberOfPorts=48,
+        operMode=None,
+        operStatus="Minor",
+        peer="",
+        peerlinkState="",
+        peerSerialNumber="",
+        peerSwitchDbId=0,
+        ports=0,
+        present=True,
+        primaryIP="",
+        primarySwitchDbID=0,
+        principal="",
+        protoDiscSettings="",
+        recvIntf="",
+        release=switch.version,
+        role="",
+        sanAnalyticsCapable=False,
+        scope="",
+        secondaryIP="",
+        secondarySwitchDbID=0,
+        sendIntf="",
+        serialNumber=switch.serial_number,
+        sharedBorder=False,
+        sourceInterface="mgmt0",
+        sourceVrf="management",
+        standbySupState=0,
+        status="",
+        switchDbID=None,
+        swType="",
+        swUUID="DCNM-UUID-TEMP",
+        swUUIDId=99999,
+        swWwn="",
+        swWwnName="",
+        sysDescr="",
+        systemMode=None,
+        uid=0,
+        unmanagableCause="",
+        upTime=0,
+        upTimeNumber=0,
+        upTimeStr="",
+        usedPorts=0,
+        username="",
+        vdcId=0,
+        vdcName="",
+        vdcMac="",
+        vendor="cisco",
+        version=switch.version,
+        vpcDomain=0,
+        vrf="management",
+        vsanWwn="",
+        vsanWwnName="",
+        waitForSwitchModeChg=False,
+        wwn="",
+    )
+
+
+def build_success_response():
+    """
+    # Summary
+
+    Build a 200 response body for a successful operation.
+
+    ## Notes
+
+    """
+    response = {"status": "Success"}
+    return copy.deepcopy(response)
+
+
+@app.delete("/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{fabric_name}")
+def v1_delete_switch(*, session: Session = Depends(get_session), fabric_name: str):
+    """
+    # Summary
+
+    DELETE request handler
+
+    ## NDFC Response
+
+    {
+        "timestamp": 1739842602937,
+        "status": 404,
+        "error": "Not Found",
+        "path": "/rest/control/fabrics/f2"
+    }
+    """
+    db_fabric = session.exec(select(Fabric).where(Fabric.FABRIC_NAME == fabric_name)).first()
+    if not db_fabric:
+        detail = {}
+        detail["timestamp"] = int(datetime.datetime.now().timestamp())
+        detail["status"] = 404
+        detail["error"] = "Not Found"
+        detail["path"] = f"/rest/control/fabrics/{fabric_name}"
+        raise HTTPException(status_code=404, detail=detail)
+    session.delete(db_fabric)
+    session.commit()
+    return {f"Fabric '{fabric_name}' is deleted successfully!"}
+
+
+@app.get(
+    "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{fabric_name}/inventory/switchesByFabric",
+    response_model=List[SwitchResponseModel],
+)
+def v1_get_switches_by_fabric_name(*, session: Session = Depends(get_session), fabric_name: str):
+    """
+    # Summary
+
+    GET request handler with fabric_name as path parameter.
+
+    Return a list of switches for a given fabric_name.
+    """
+    db_fabric = session.exec(select(Fabric).where(Fabric.FABRIC_NAME == fabric_name)).first()
+    if not db_fabric:
+        raise HTTPException(status_code=404, detail=f"Fabric {fabric_name} not found")
+    fabric_id = db_fabric.id
+    db_switches = session.exec(select(SwitchDbModel).where(SwitchDbModel.fabricId == fabric_id)).all()
+    if len(db_switches) == 0:
+        raise HTTPException(status_code=404, detail=f"No switches found for fabric {fabric_name}")
+    response = [build_response_switch(db_switch) for db_switch in db_switches]
+    return response
+
+
+@app.post("/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{fabric_name}/inventory/discover")
+def v1_post_discover_switches(*, session: Session = Depends(get_session), fabric_name: str, switch_discovery_body: SwitchDiscoverBodyModel):
+    """
+    # Summary
+
+    POST request handler with fabric_name as path parameter.
+
+    Discover switches for a given fabric_name.
+    """
+    db_fabric = session.exec(select(Fabric).where(Fabric.FABRIC_NAME == fabric_name)).first()
+    if not db_fabric:
+        raise HTTPException(status_code=404, detail=f"Fabric {fabric_name} not found")
+    fabric_id = db_fabric.id
+    db_switches = session.exec(select(SwitchDbModel).where(SwitchDbModel.fabricId == fabric_id)).all()
+    for db_switch in db_switches:
+        if db_switch.serialNumber in [discovery_body.serial_number for discovery_body in switch_discovery_body.switches]:
+            raise HTTPException(status_code=500, detail=f"Switch {db_switch.serialNumber} already exists in fabric {fabric_name}")
+    for discovery_body in switch_discovery_body.switches:
+        db_switch = build_db_switch(discovery_body, db_fabric)
+        session.add(db_switch)
+    session.commit()
+    response = build_success_response()
+    return response

--- a/app/v1/endpoints/inventory.py
+++ b/app/v1/endpoints/inventory.py
@@ -159,7 +159,7 @@ def build_db_switch(switch: SwitchDiscoverItem, db_fabric: Fabric) -> SwitchDbMo
         domainID=0,
         elementType="",
         fabricId=db_fabric.id,
-        fabricName="",
+        fabricName=db_fabric.FABRIC_NAME,
         fabricTechnology=db_fabric.FF,
         fcoeEnabled=False,
         fex=False,

--- a/app/v1/endpoints/lan_fabric/rest_control_switches_fabric_name.py
+++ b/app/v1/endpoints/lan_fabric/rest_control_switches_fabric_name.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+from fastapi import Depends, HTTPException
+from sqlmodel import Field, Session, SQLModel, select
+
+from ....app import app
+from ....db import get_session
+from ...models.inventory import SwitchDbModel
+
+
+class SwitchFabricNameResponseModel(SQLModel):
+    """
+    Response model for endpoint v1_get_fabric_name_by_switch_serial_number().
+    """
+
+    fabricName: str = Field(min_length=1, max_length=32)
+
+
+def build_response_fabric_name(db_switch: SwitchDbModel) -> SwitchFabricNameResponseModel:
+    """
+    # Summary
+
+    Return response for v1_get_fabric_name_by_switch_serial_number()
+    """
+    return SwitchFabricNameResponseModel(
+        fabricName=db_switch.fabricName,
+    )
+
+
+@app.get(
+    "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/switches/{switch_serial_number}/fabric-name",
+    response_model=SwitchFabricNameResponseModel,
+)
+def v1_get_fabric_name_by_switch_serial_number(*, session: Session = Depends(get_session), switch_serial_number: str):
+    """
+    # Summary
+
+    Return fabric name assocated with switch_serial_number, if it exists.
+    """
+    db_switch = session.exec(select(SwitchDbModel).where(SwitchDbModel.serialNumber == switch_serial_number)).first()
+    if db_switch is None:
+        raise HTTPException(status_code=404, detail=f"Switch {switch_serial_number} not found")
+    print(f"ZZZ: Switch {switch_serial_number} found")
+    print(f"ZZZ: db_switch: {db_switch}")
+    return build_response_fabric_name(db_switch)

--- a/app/v1/endpoints/lan_fabric/rest_control_switches_overview.py
+++ b/app/v1/endpoints/lan_fabric/rest_control_switches_overview.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 import copy
 
-from ...app import app
-from ..models.lan_fabric_rest_control_switches_overview import V1LanFabricRestControlSwitchesOverviewResponseModel
+from ....app import app
+from ...models.lan_fabric_rest_control_switches_overview import V1LanFabricRestControlSwitchesOverviewResponseModel
 
 
 def build_response():

--- a/app/v1/models/fabric.py
+++ b/app/v1/models/fabric.py
@@ -5,7 +5,7 @@
 from datetime import datetime
 from enum import Enum
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import ConfigDict
 from sqlmodel import Field, SQLModel
 
 from ...common.functions.utilities import get_datetime
@@ -1611,6 +1611,7 @@ class Fabric(FabricBase, table=True):
     Define the fabric table in the database.
     """
 
+    model_config = ConfigDict(use_enum_values=True)
     id: int | None = Field(default=None, primary_key=True)
     created_at: datetime | None = Field(default_factory=get_datetime)
 
@@ -1627,6 +1628,8 @@ class FabricCreate(FabricBase):
     Used to validate POST request content.
     """
 
+    model_config = ConfigDict(use_enum_values=True, validate_default=True)
+
 
 class NvPairs(FabricBase):
     """
@@ -1636,16 +1639,20 @@ class NvPairs(FabricBase):
     response.
     """
 
+    model_config = ConfigDict(use_enum_values=True)
+
     # created_at: datetime | None
     # updated_at: datetime | None
 
 
-class FabricResponseModel(BaseModel):
+class FabricResponseModel(SQLModel):
     """
     # Summary
 
     Describes what is returned to clients.
     """
+
+    model_config = ConfigDict(use_enum_values=True)
 
     id: int
     nvPairs: NvPairs
@@ -1657,6 +1664,8 @@ class FabricUpdate(SQLModel):
 
     Used to validate PUT requests.
     """
+
+    model_config = ConfigDict(use_enum_values=True)
 
     AAA_REMOTE_IP_ENABLED: bool | None = None
     AAA_SERVER_CONF: str | None = None

--- a/app/v1/models/inventory.py
+++ b/app/v1/models/inventory.py
@@ -1,0 +1,190 @@
+from typing import List
+
+from pydantic import BaseModel, ConfigDict
+from sqlmodel import Field, SQLModel
+
+from ...common.enums.switch import SwitchRoleEnum, SwitchRoleFriendlyEnum, SwitchUnmanageableCauseEnum
+
+
+class SwitchBase(SQLModel):
+    """
+    Base representation of a switch.
+    """
+
+    model_config = ConfigDict(use_enum_values=True, validate_default=True)
+
+    activeSupSlot: int
+    availPorts: int
+    ccStatus: str
+    cfsSyslogStatus: int
+    colDBId: int
+    connUnitStatus: int
+    consistencyState: bool
+    contact: str | None
+    cpuUsage: int
+    deviceType: str
+    displayHdrs: str | None
+    displayValues: str | None
+    domain: str | None
+    domainID: int
+    elementType: str | None
+    fabricId: int
+    fabricName: str
+    fabricTechnology: str
+    fcoeEnabled: bool
+    fex: bool
+    fid: int
+    freezeMode: str | None
+    health: int
+    hostName: str
+    index: int
+    intentedpeerName: str
+    interfaces: str | None
+    ipAddress: str
+    ipDomain: str
+    isEchSupport: bool
+    isLan: bool
+    isNonNexus: bool
+    isPmCollect: bool
+    isSharedBorder: bool
+    isTrapDelayed: bool
+    isVpcConfigured: bool
+    is_smlic_enabled: bool
+    keepAliveState: str | None
+    lastScanTime: int
+    licenseDetail: str | None
+    licenseViolation: bool
+    linkName: str | None
+    location: str | None = Field(default="")
+    logicalName: str
+    managable: bool
+    mds: bool
+    membership: str | None = Field(default="")
+    memoryUsage: int
+    mgmtAddress: str | None = Field(default="")
+    mode: str
+    model: str
+    modelType: int
+    moduleIndexOffset: int
+    modules: str | None
+    monitorMode: str | None
+    name: str | None
+    network: str | None
+    nonMdsModel: str | None
+    npvEnabled: bool
+    numberOfPorts: int
+    operMode: str | None
+    operStatus: str
+    peer: str | None
+    peerSerialNumber: str | None
+    peerSwitchDbId: int
+    peerlinkState: str | None
+    ports: int
+    present: bool
+    primaryIP: str
+    primarySwitchDbID: int
+    principal: str | None
+    protoDiscSettings: str | None
+    recvIntf: str | None
+    release: str
+    role: str | None
+    sanAnalyticsCapable: bool
+    scope: str | None
+    secondaryIP: str
+    secondarySwitchDbID: int
+    sendIntf: str | None
+    serialNumber: str
+    sharedBorder: bool
+    sourceInterface: str
+    sourceVrf: str
+    standbySupState: int
+    status: str
+    swType: str | None
+    swUUID: str
+    swUUIDId: int | None
+    swWwn: str | None
+    swWwnName: str | None
+    switchDbID: int
+    switchRole: SwitchRoleFriendlyEnum = Field(default=SwitchRoleFriendlyEnum.leaf)
+    switchRoleEnum: SwitchRoleEnum = Field(default=SwitchRoleEnum.leaf)
+    sysDescr: str
+    systemMode: str = Field(default="Normal")
+    uid: int
+    unmanagableCause: str = Field(default=SwitchUnmanageableCauseEnum.none)
+    upTime: int
+    upTimeNumber: int
+    upTimeStr: str
+    usedPorts: int
+    username: str | None
+    vdcId: int
+    vdcMac: str | None
+    vdcName: str
+    vendor: str
+    version: str | None
+    vpcDomain: int
+    vrf: str
+    vsanWwn: str | None
+    vsanWwnName: str | None
+    waitForSwitchModeChg: bool
+    wwn: str | None
+
+
+class SwitchResponseModel(SwitchBase):
+    """
+    Representation of a switch in a response.
+    """
+
+    model_config = ConfigDict(use_enum_values=True)
+
+    fexMap: dict
+
+
+class SwitchDbModel(SwitchBase, table=True):
+    """
+    Representation of a switch in the database.
+    """
+
+    model_config = ConfigDict(use_enum_values=True)
+
+    hostName: str = Field(index=True)
+    ipAddress: str = Field(index=True, unique=True)
+    switchDbID: int | None = Field(default=None, primary_key=True)
+    serialNumber: str = Field(index=True, unique=True)
+
+
+class SwitchDiscoverItem(BaseModel):
+    """
+    Representation of a switch in a discovery.
+    """
+
+    model_config = ConfigDict(use_enum_values=True)
+
+    deviceIndex: str
+    serial_number: str
+    sysName: str
+    platform: str
+    version: str
+    ipaddr: str
+
+
+class SwitchDiscoverSucessResponseModel(BaseModel):
+    """
+    Representation of a switch discovery success response.
+    """
+
+    model_config = ConfigDict(use_enum_values=True)
+    status: str
+
+
+class SwitchDiscoverBodyModel(BaseModel):
+    """
+    Representation of a switch discovery request body.
+    """
+
+    model_config = ConfigDict(use_enum_values=True)
+
+    seedIP: str
+    username: str
+    password: str
+    preserveConfig: bool
+    switches: List[SwitchDiscoverItem]

--- a/app/v1/models/inventory.py
+++ b/app/v1/models/inventory.py
@@ -1,3 +1,6 @@
+# TODO: If SQLModel is ever fixed, remove the mypy directive below.
+# https://github.com/fastapi/sqlmodel/discussions/732
+# mypy: disable-error-code=call-arg
 from typing import List
 
 from pydantic import BaseModel, ConfigDict


### PR DESCRIPTION
# Summary

Initial support for adding switches to fabrics.

- Add support for endpoints:

GET: ./v1/lan-fabric/rest/control/fabrics/{fabric_name}/inventory/switchesByFabric

PUT: ./v1/lan-fabric/rest/control/fabrics/{fabric_name}/inventory/discover

- Add associated database tables
- Initial reorganization of endpoints (under v1/lan_fabric)

## 1. app/common/enums/switch.py

Add enums

- SwitchRoleFriendlyEnum
- SwitchUnmanageableCauseEnum

## 2. app/main.py

Update imports

## 3. app/v1/endpoints/inventory.py

Add support for the following endpoints:

### 1. v1_get_switches_by_fabric_name()

- Verb: GET
- Path: /appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{fabric_name}/inventory/switchesByFabric

### 2.  v1_post_discover_switches()

- Verb: POST
- Path: /appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{fabric_name}/inventory/discover

TODO: Add DELETE endpoint

## 4. app/v1/models/fabric.py

- Add model_config with use_enum_value to several models
- FabricResponseModel() inherit from SQLModel rather than BaseModel

## 5.. app/v1/models/inventory.py

- Add models

- SwitchBase
- SwitchResponseModel(SwitchBase)
- SwitchDbModel(SwitchBase, table=True)
- SwitchDiscoverItem(BaseModel)
- SwitchDiscoverSucessResponseModel(BaseModel)
- SwitchDiscoverBodyModel(BaseModel)

--

## 6. app/v1/endpoints/inventory.py

- Populate fabricName when saving to database

## 7. app/v1/endpoints/lan_fabric/rest_control_switches_fabric_name.py

- Add endpoint

/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/switches/{switch_serial_number}/fabric-name

## 8.  app/v1/endpoints/lan_fabric/rest_control_switches_overview.py

- Rename from app/v1/endpoints/lan_fabric_rest_control_switches_overview.py
