### PR TITLE
Refactor router for rest/control/switches/fabric-name

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -6,10 +6,11 @@ from .v1.endpoints.fabric import v1_delete_fabric, v1_get_fabric_by_fabric_name,
 from .v1.endpoints.fm_about_version import get_v1_fm_about_version
 from .v1.endpoints.fm_features import get_v1_fm_features
 from .v1.endpoints.lan_fabric.rest.control.fabrics.inventory import v1_get_inventory_switches_by_fabric, v1_post_inventory_discover
-from .v1.endpoints.lan_fabric.rest.control.switches import roles
+from .v1.endpoints.lan_fabric.rest.control.switches import fabric_name, roles
 from .v1.endpoints.lan_fabric.rest.control.switches.fabric_name import v1_get_fabric_name_by_switch_serial_number
 from .v1.endpoints.lan_fabric.rest.control.switches.overview import v1_lan_fabric_rest_control_switches_overview_by_fabric_name
 from .v1.endpoints.login import post_login
 from .v2.endpoints.fabric import v2_delete_fabric, v2_get_fabric_by_fabric_name, v2_get_fabrics, v2_post_fabric, v2_put_fabric
 
+app.include_router(fabric_name.router, tags=["Switches"])
 app.include_router(roles.router, tags=["Inventory"])

--- a/app/v1/endpoints/lan_fabric/rest/control/switches/fabric_name.py
+++ b/app/v1/endpoints/lan_fabric/rest/control/switches/fabric_name.py
@@ -1,10 +1,13 @@
 #!/usr/bin/env python
-from fastapi import Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from sqlmodel import Field, Session, SQLModel, select
 
-from .......app import app
 from .......db import get_session
 from ......models.inventory import SwitchDbModel
+
+router = APIRouter(
+    prefix="/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/switches",
+)
 
 
 class SwitchFabricNameResponseModel(SQLModel):
@@ -26,9 +29,10 @@ def build_response_fabric_name(db_switch: SwitchDbModel) -> SwitchFabricNameResp
     )
 
 
-@app.get(
-    "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/switches/{switch_serial_number}/fabric-name",
+@router.get(
+    "/{switch_serial_number}/fabric-name",
     response_model=SwitchFabricNameResponseModel,
+    description="Return fabric name assocated with switch_serial_number, if it exists.",
 )
 def v1_get_fabric_name_by_switch_serial_number(*, session: Session = Depends(get_session), switch_serial_number: str):
     """
@@ -39,6 +43,4 @@ def v1_get_fabric_name_by_switch_serial_number(*, session: Session = Depends(get
     db_switch = session.exec(select(SwitchDbModel).where(SwitchDbModel.serialNumber == switch_serial_number)).first()
     if db_switch is None:
         raise HTTPException(status_code=404, detail=f"Switch {switch_serial_number} not found")
-    print(f"ZZZ: Switch {switch_serial_number} found")
-    print(f"ZZZ: db_switch: {db_switch}")
     return build_response_fabric_name(db_switch)

--- a/app/v1/endpoints/lan_fabric/rest/control/switches/roles.py
+++ b/app/v1/endpoints/lan_fabric/rest/control/switches/roles.py
@@ -8,7 +8,6 @@ from ......models.inventory import SwitchDbModel
 
 router = APIRouter(
     prefix="/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/switches",
-    tags=["Inventory"],
 )
 
 


### PR DESCRIPTION
# Summary

Refactor rest/control/switches/{serial_number}/fabric-name to use its own router instance.

## ./app/v1/endpoints/lan_fabric/rest/control/switches/fabric_name.py

- Remove app import
- Instantiate APIRouter() and leverage v1_get_fabric_name_by_switch_serial_number() decorator.

## ./app/v1/endpoints/lan_fabric/rest/control/switches/roles.py

- Remove tags from APIRouter instantiation.

## ./app/main.py

- Update imports
- Standardize on setting tags here rather than in individual endpoint handler files.
  - Add tags for roles and fabric_name