### PR TITLE
Refactor router for rest/control/switches/{fabric_name}/overview

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -6,11 +6,12 @@ from .v1.endpoints.fabric import v1_delete_fabric, v1_get_fabric_by_fabric_name,
 from .v1.endpoints.fm_about_version import get_v1_fm_about_version
 from .v1.endpoints.fm_features import get_v1_fm_features
 from .v1.endpoints.lan_fabric.rest.control.fabrics.inventory import v1_get_inventory_switches_by_fabric, v1_post_inventory_discover
-from .v1.endpoints.lan_fabric.rest.control.switches import fabric_name, roles
+from .v1.endpoints.lan_fabric.rest.control.switches import fabric_name, overview, roles
 from .v1.endpoints.lan_fabric.rest.control.switches.fabric_name import v1_get_fabric_name_by_switch_serial_number
 from .v1.endpoints.lan_fabric.rest.control.switches.overview import v1_lan_fabric_rest_control_switches_overview_by_fabric_name
 from .v1.endpoints.login import post_login
 from .v2.endpoints.fabric import v2_delete_fabric, v2_get_fabric_by_fabric_name, v2_get_fabrics, v2_post_fabric, v2_put_fabric
 
 app.include_router(fabric_name.router, tags=["Switches"])
+app.include_router(overview.router, tags=["Switches"])
 app.include_router(roles.router, tags=["Inventory"])

--- a/app/v1/endpoints/lan_fabric/rest/control/switches/overview.py
+++ b/app/v1/endpoints/lan_fabric/rest/control/switches/overview.py
@@ -1,8 +1,13 @@
 #!/usr/bin/env python
 import copy
 
-from .......app import app
+from fastapi import APIRouter
+
 from ......models.lan_fabric_rest_control_switches_overview import V1LanFabricRestControlSwitchesOverviewResponseModel
+
+router = APIRouter(
+    prefix="/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/switches",
+)
 
 
 def build_response():
@@ -18,9 +23,8 @@ def build_response():
     accessed by ansible-dcnm Fabric().Deleted() to determine if any switches
     are present in the fabric.
 
-    TODO: We need to create an entire inventory structure for the database,
-    which will include tables to be updated when switches are "added" to
-    or "deleted" from fabrics.
+    TODO: Need to reference switch tables for this info.
+    TODO: Need to raise HTTPException if fabric does not exist.
     """
     response = {
         "switchSWVersions": {"10.2(5)": 7, "10.3(1)": 2},
@@ -32,9 +36,10 @@ def build_response():
     return copy.deepcopy(response)
 
 
-@app.get(
-    "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/switches/{fabric_name}/overview",
+@router.get(
+    "/{fabric_name}/overview",
     response_model=V1LanFabricRestControlSwitchesOverviewResponseModel,
+    description="Return summary of fabric inventory.",
 )
 def v1_lan_fabric_rest_control_switches_overview_by_fabric_name():
     """


### PR DESCRIPTION
closes #16 

# Summary

Refactor  rest/control/switches/{fabric_name}/overview to use its own router instance.

## ./app/main.py

- Update imports
- app.include_router(overview.router)

## ./app/v1/endpoints/lan_fabric/rest/control/switches/overview.py

- Remove app import
- Instantiate APIRouter() and leverage in decorator fo handler method.

