### PR TITLE
Refactor fabric delete

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2,9 +2,10 @@
 # pylint: disable=unused-import
 from .app import app
 from .v1.endpoints.configtemplate.rest.config.templates import config_template_by_name
-from .v1.endpoints.fabric import v1_delete_fabric, v1_get_fabric_by_fabric_name, v1_get_fabrics, v1_post_fabric, v1_put_fabric
+from .v1.endpoints.fabric import v1_get_fabric_by_fabric_name, v1_get_fabrics, v1_post_fabric, v1_put_fabric
 from .v1.endpoints.fm_about_version import get_v1_fm_about_version
 from .v1.endpoints.fm_features import get_v1_fm_features
+from .v1.endpoints.lan_fabric.rest.control.fabrics import fabric_delete
 from .v1.endpoints.lan_fabric.rest.control.fabrics.inventory import v1_get_inventory_switches_by_fabric, v1_post_inventory_discover
 from .v1.endpoints.lan_fabric.rest.control.switches import fabric_name, overview, roles
 from .v1.endpoints.lan_fabric.rest.control.switches.fabric_name import v1_get_fabric_name_by_switch_serial_number
@@ -12,7 +13,8 @@ from .v1.endpoints.lan_fabric.rest.control.switches.overview import v1_lan_fabri
 from .v1.endpoints.login import post_login
 from .v2.endpoints.fabric import v2_delete_fabric, v2_get_fabric_by_fabric_name, v2_get_fabrics, v2_post_fabric, v2_put_fabric
 
-app.include_router(config_template_by_name.router, tags=["Templates"])
+app.include_router(fabric_delete.router, tags=["Fabrics"])
+app.include_router(roles.router, tags=["Inventory"])
 app.include_router(fabric_name.router, tags=["Switches"])
 app.include_router(overview.router, tags=["Switches"])
-app.include_router(roles.router, tags=["Inventory"])
+app.include_router(config_template_by_name.router, tags=["Templates"])

--- a/app/v1/endpoints/fabric.py
+++ b/app/v1/endpoints/fabric.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 import copy
-import datetime
 from typing import List
 
 from fastapi import Depends, HTTPException, Query
@@ -34,35 +33,6 @@ def build_nv_pairs(fabric):
     Build the nvPairs object in a fabric response.
     """
     return fabric.model_dump()
-
-
-@app.delete("/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{fabric_name}")
-def v1_delete_fabric(*, session: Session = Depends(get_session), fabric_name: str):
-    """
-    # Summary
-
-    DELETE request handler
-
-    ## NDFC Response
-
-    {
-        "timestamp": 1739842602937,
-        "status": 404,
-        "error": "Not Found",
-        "path": "/rest/control/fabrics/f2"
-    }
-    """
-    db_fabric = session.exec(select(Fabric).where(Fabric.FABRIC_NAME == fabric_name)).first()
-    if not db_fabric:
-        detail = {}
-        detail["timestamp"] = int(datetime.datetime.now().timestamp())
-        detail["status"] = 404
-        detail["error"] = "Not Found"
-        detail["path"] = f"/rest/control/fabrics/{fabric_name}"
-        raise HTTPException(status_code=404, detail=detail)
-    session.delete(db_fabric)
-    session.commit()
-    return {f"Fabric '{fabric_name}' is deleted successfully!"}
 
 
 @app.get(

--- a/app/v1/endpoints/lan_fabric/rest/control/fabrics/fabric_delete.py
+++ b/app/v1/endpoints/lan_fabric/rest/control/fabrics/fabric_delete.py
@@ -1,0 +1,40 @@
+import datetime
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlmodel import Session, select
+
+from .......db import get_session
+from ......models.fabric import Fabric
+
+router = APIRouter(
+    prefix="/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics",
+)
+
+
+@router.delete("/{fabric_name}", description="(v1) Delete a fabric by name.")
+def v1_fabric_delete(*, session: Session = Depends(get_session), fabric_name: str):
+    """
+    # Summary
+
+    DELETE request handler
+
+    ## NDFC Response
+
+    {
+        "timestamp": 1739842602937,
+        "status": 404,
+        "error": "Not Found",
+        "path": "/rest/control/fabrics/f2"
+    }
+    """
+    db_fabric = session.exec(select(Fabric).where(Fabric.FABRIC_NAME == fabric_name)).first()
+    if not db_fabric:
+        detail = {}
+        detail["timestamp"] = int(datetime.datetime.now().timestamp())
+        detail["status"] = 404
+        detail["error"] = "Not Found"
+        detail["path"] = f"/rest/control/fabrics/{fabric_name}"
+        raise HTTPException(status_code=404, detail=detail)
+    session.delete(db_fabric)
+    session.commit()
+    return {f"Fabric '{fabric_name}' is deleted successfully!"}


### PR DESCRIPTION
closes #20 

# Summary

Refactor  the router for the following endpoint:

Verb: DELETE
Path: `/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{fabric_name}`

## Move endpoint handler to a new file in a directory aligned with NDFC endpoint path

v1/endpoints/lan_fabric/rest/config/fabrics/fabric_delete.py

## ./app/main.py

- Update imports
app.include_router(fabric_delete.router, tags=["Fabrics"])


## ./app/v1/endpoints/fabric.py

- Remove old fabric_delete handler
- 