### PR TITLE
Refactor router for fabrics_get endpoint

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2,10 +2,10 @@
 # pylint: disable=unused-import
 from .app import app
 from .v1.endpoints.configtemplate.rest.config.templates import config_template_by_name
-from .v1.endpoints.fabric import v1_get_fabric_by_fabric_name, v1_get_fabrics, v1_post_fabric, v1_put_fabric
+from .v1.endpoints.fabric import v1_get_fabric_by_fabric_name, v1_post_fabric, v1_put_fabric
 from .v1.endpoints.fm_about_version import get_v1_fm_about_version
 from .v1.endpoints.fm_features import get_v1_fm_features
-from .v1.endpoints.lan_fabric.rest.control.fabrics import fabric_delete
+from .v1.endpoints.lan_fabric.rest.control.fabrics import fabric_delete, fabrics_get
 from .v1.endpoints.lan_fabric.rest.control.fabrics.inventory import v1_get_inventory_switches_by_fabric, v1_post_inventory_discover
 from .v1.endpoints.lan_fabric.rest.control.switches import fabric_name, overview, roles
 from .v1.endpoints.lan_fabric.rest.control.switches.fabric_name import v1_get_fabric_name_by_switch_serial_number
@@ -14,6 +14,7 @@ from .v1.endpoints.login import post_login
 from .v2.endpoints.fabric import v2_delete_fabric, v2_get_fabric_by_fabric_name, v2_get_fabrics, v2_post_fabric, v2_put_fabric
 
 app.include_router(fabric_delete.router, tags=["Fabrics"])
+app.include_router(fabrics_get.router, tags=["Fabrics"])
 app.include_router(roles.router, tags=["Inventory"])
 app.include_router(fabric_name.router, tags=["Switches"])
 app.include_router(overview.router, tags=["Switches"])

--- a/app/v1/endpoints/fabric.py
+++ b/app/v1/endpoints/fabric.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python
 import copy
-from typing import List
 
-from fastapi import Depends, HTTPException, Query
+from fastapi import Depends, HTTPException
 from sqlmodel import Session, select
 
 from ...app import app
@@ -33,30 +32,6 @@ def build_nv_pairs(fabric):
     Build the nvPairs object in a fabric response.
     """
     return fabric.model_dump()
-
-
-@app.get(
-    "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/",
-    response_model=List[FabricResponseModel],
-)
-def v1_get_fabrics(
-    *,
-    session: Session = Depends(get_session),
-    offset: int = 0,
-    limit: int = Query(default=100, le=100),
-):
-    """
-    # Summary
-
-    GET request handler with limit and offset query parameters.
-    """
-    fabrics = session.exec(select(Fabric).offset(offset).limit(limit)).all()
-    response = []
-    response_fabric = {}
-    for fabric in fabrics:
-        response_fabric = build_response(fabric)
-        response.append(copy.deepcopy(response_fabric))
-    return response
 
 
 @app.get(

--- a/app/v1/endpoints/lan_fabric/rest/control/fabrics/common.py
+++ b/app/v1/endpoints/lan_fabric/rest/control/fabrics/common.py
@@ -1,0 +1,26 @@
+import copy
+
+
+def build_nv_pairs(fabric):
+    """
+    # Summary
+
+    Build the nvPairs object in a fabric response.
+    """
+    return fabric.model_dump()
+
+
+def build_response(fabric):
+    """
+    # Summary
+
+    Build a fabric response that aligns with FabricResponseModel
+
+    ## Notes
+
+    1. If FabricResponseModel is changed, this function must also be updated
+    """
+    response = {}
+    response["id"] = fabric.id
+    response["nvPairs"] = build_nv_pairs(fabric)
+    return copy.deepcopy(response)

--- a/app/v1/endpoints/lan_fabric/rest/control/fabrics/fabrics_get.py
+++ b/app/v1/endpoints/lan_fabric/rest/control/fabrics/fabrics_get.py
@@ -1,0 +1,34 @@
+import copy
+from typing import List
+
+from fastapi import APIRouter, Depends, Query
+from sqlmodel import Session, select
+
+from .......db import get_session
+from ......models.fabric import Fabric, FabricResponseModel
+from .common import build_response
+
+router = APIRouter(
+    prefix="/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics",
+)
+
+
+@router.get("/", response_model=List[FabricResponseModel], description="(v1) Get all fabrics.")
+def v1_fabrics_get(
+    *,
+    session: Session = Depends(get_session),
+    offset: int = 0,
+    limit: int = Query(default=100, le=100),
+):
+    """
+    # Summary
+
+    GET request handler with limit and offset query parameters.
+    """
+    fabrics = session.exec(select(Fabric).offset(offset).limit(limit)).all()
+    response = []
+    response_fabric = {}
+    for fabric in fabrics:
+        response_fabric = build_response(fabric)
+        response.append(copy.deepcopy(response_fabric))
+    return response


### PR DESCRIPTION
closes #22 

# Summary

Refactor  the router for the following endpoint:

Verb: GET
Path: `/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics`

## Move endpoint handler to a new file in a directory aligned with NDFC endpoint path

v1/endpoints/lan_fabric/rest/config/fabrics/fabrics_get.py

## ./app/main.py

- Update imports
app.include_router(fabrics_get.router, tags=["Fabrics"])


## ./app/v1/endpoints/fabric.py

- Remove old fabrics_get handler
