### PR TITLE
fabric_get: Refactor router

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2,10 +2,10 @@
 # pylint: disable=unused-import
 from .app import app
 from .v1.endpoints.configtemplate.rest.config.templates import config_template_by_name
-from .v1.endpoints.fabric import v1_get_fabric_by_fabric_name, v1_post_fabric, v1_put_fabric
+from .v1.endpoints.fabric import v1_post_fabric, v1_put_fabric
 from .v1.endpoints.fm_about_version import get_v1_fm_about_version
 from .v1.endpoints.fm_features import get_v1_fm_features
-from .v1.endpoints.lan_fabric.rest.control.fabrics import fabric_delete, fabrics_get
+from .v1.endpoints.lan_fabric.rest.control.fabrics import fabric_delete, fabric_get, fabrics_get
 from .v1.endpoints.lan_fabric.rest.control.fabrics.inventory import v1_get_inventory_switches_by_fabric, v1_post_inventory_discover
 from .v1.endpoints.lan_fabric.rest.control.switches import fabric_name, overview, roles
 from .v1.endpoints.lan_fabric.rest.control.switches.fabric_name import v1_get_fabric_name_by_switch_serial_number
@@ -13,9 +13,10 @@ from .v1.endpoints.lan_fabric.rest.control.switches.overview import v1_lan_fabri
 from .v1.endpoints.login import post_login
 from .v2.endpoints.fabric import v2_delete_fabric, v2_get_fabric_by_fabric_name, v2_get_fabrics, v2_post_fabric, v2_put_fabric
 
-app.include_router(fabric_delete.router, tags=["Fabrics"])
-app.include_router(fabrics_get.router, tags=["Fabrics"])
-app.include_router(roles.router, tags=["Inventory"])
-app.include_router(fabric_name.router, tags=["Switches"])
-app.include_router(overview.router, tags=["Switches"])
-app.include_router(config_template_by_name.router, tags=["Templates"])
+app.include_router(fabric_delete.router, tags=["Fabrics (v1)"])
+app.include_router(fabric_get.router, tags=["Fabrics (v1)"])
+app.include_router(fabrics_get.router, tags=["Fabrics (v1)"])
+app.include_router(roles.router, tags=["Inventory (v1)"])
+app.include_router(fabric_name.router, tags=["Switches (v1)"])
+app.include_router(overview.router, tags=["Switches (v1)"])
+app.include_router(config_template_by_name.router, tags=["Templates (v1)"])

--- a/app/v1/endpoints/fabric.py
+++ b/app/v1/endpoints/fabric.py
@@ -34,23 +34,6 @@ def build_nv_pairs(fabric):
     return fabric.model_dump()
 
 
-@app.get(
-    "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{fabric_name}",
-    response_model=FabricResponseModel,
-)
-def v1_get_fabric_by_fabric_name(*, session: Session = Depends(get_session), fabric_name: str):
-    """
-    # Summary
-
-    GET request handler with fabric_name as path parameter.
-    """
-    db_fabric = session.exec(select(Fabric).where(Fabric.FABRIC_NAME == fabric_name)).first()
-    if not db_fabric:
-        raise HTTPException(status_code=404, detail=f"Fabric {fabric_name} not found")
-    response = build_response(db_fabric)
-    return response
-
-
 @app.post(
     "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{fabric_name}/{template_name}",
     response_model=FabricResponseModel,

--- a/app/v1/endpoints/lan_fabric/rest/control/fabrics/fabric_get.py
+++ b/app/v1/endpoints/lan_fabric/rest/control/fabrics/fabric_get.py
@@ -1,0 +1,28 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlmodel import Session, select
+
+from .......db import get_session
+from ......models.fabric import Fabric, FabricResponseModel
+from .common import build_response
+
+router = APIRouter(
+    prefix="/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics",
+)
+
+
+@router.get(
+    "/{fabric_name}",
+    response_model=FabricResponseModel,
+    description="(v1) Get a fabric by fabric name.",
+)
+def v1_get_fabric_by_fabric_name(*, session: Session = Depends(get_session), fabric_name: str):
+    """
+    # Summary
+
+    GET request handler with fabric_name as path parameter.
+    """
+    db_fabric = session.exec(select(Fabric).where(Fabric.FABRIC_NAME == fabric_name)).first()
+    if not db_fabric:
+        raise HTTPException(status_code=404, detail=f"Fabric {fabric_name} not found")
+    response = build_response(db_fabric)
+    return response


### PR DESCRIPTION
closes #24 

# Summary

Refactor  the router for the following endpoint:

Verb: GET
Path: `/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{fabric_name}`

## Move endpoint handler to a new file in a directory aligned with NDFC endpoint path

v1/endpoints/lan_fabric/rest/config/fabrics/fabric_get.py

## ./app/main.py

- Update imports
- Add app.include_router(fabric_get.router, tags=["Fabrics (v1)"])
- Modify all other tags to include the API version.

## ./app/v1/endpoints/fabric.py

- v1_get_fabric_by_fabric_name() - Remove old fabric_get handler