### PR TITLE
fabric_post: Refactor router

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2,10 +2,10 @@
 # pylint: disable=unused-import
 from .app import app
 from .v1.endpoints.configtemplate.rest.config.templates import config_template_by_name
-from .v1.endpoints.fabric import v1_post_fabric, v1_put_fabric
+from .v1.endpoints.fabric import v1_put_fabric
 from .v1.endpoints.fm_about_version import get_v1_fm_about_version
 from .v1.endpoints.fm_features import get_v1_fm_features
-from .v1.endpoints.lan_fabric.rest.control.fabrics import fabric_delete, fabric_get, fabrics_get
+from .v1.endpoints.lan_fabric.rest.control.fabrics import fabric_delete, fabric_get, fabric_post, fabrics_get
 from .v1.endpoints.lan_fabric.rest.control.fabrics.inventory import v1_get_inventory_switches_by_fabric, v1_post_inventory_discover
 from .v1.endpoints.lan_fabric.rest.control.switches import fabric_name, overview, roles
 from .v1.endpoints.lan_fabric.rest.control.switches.fabric_name import v1_get_fabric_name_by_switch_serial_number
@@ -15,6 +15,7 @@ from .v2.endpoints.fabric import v2_delete_fabric, v2_get_fabric_by_fabric_name,
 
 app.include_router(fabric_delete.router, tags=["Fabrics (v1)"])
 app.include_router(fabric_get.router, tags=["Fabrics (v1)"])
+app.include_router(fabric_post.router, tags=["Fabrics (v1)"])
 app.include_router(fabrics_get.router, tags=["Fabrics (v1)"])
 app.include_router(roles.router, tags=["Inventory (v1)"])
 app.include_router(fabric_name.router, tags=["Switches (v1)"])

--- a/app/v1/endpoints/fabric.py
+++ b/app/v1/endpoints/fabric.py
@@ -6,7 +6,7 @@ from sqlmodel import Session, select
 
 from ...app import app
 from ...db import get_session
-from ..models.fabric import Fabric, FabricCreate, FabricResponseModel, FabricUpdate
+from ..models.fabric import Fabric, FabricResponseModel, FabricUpdate
 
 
 def build_response(fabric):
@@ -32,39 +32,6 @@ def build_nv_pairs(fabric):
     Build the nvPairs object in a fabric response.
     """
     return fabric.model_dump()
-
-
-@app.post(
-    "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{fabric_name}/{template_name}",
-    response_model=FabricResponseModel,
-)
-def v1_post_fabric(
-    *,
-    session: Session = Depends(get_session),
-    fabric_name: str,
-    template_name: str,
-    fabric: FabricCreate,
-):
-    """
-    # Summary
-
-    POST request handler
-    """
-    db_fabric = Fabric.model_validate(fabric)
-    setattr(db_fabric, "FABRIC_NAME", fabric_name)
-    setattr(db_fabric, "FF", template_name)
-
-    session.add(db_fabric)
-    try:
-        session.commit()
-    except Exception as error:
-        # print(f"Error: {error}")
-        session.rollback()
-        msg = f"ND Site with name {fabric_name} already exists."
-        raise HTTPException(status_code=500, detail=msg) from error
-    session.refresh(db_fabric)
-    response = build_response(db_fabric)
-    return response
 
 
 @app.put(

--- a/app/v1/endpoints/lan_fabric/rest/control/fabrics/fabric_post.py
+++ b/app/v1/endpoints/lan_fabric/rest/control/fabrics/fabric_post.py
@@ -1,0 +1,44 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlmodel import Session
+
+from .......db import get_session
+from ......models.fabric import Fabric, FabricCreate, FabricResponseModel
+from .common import build_response
+
+router = APIRouter(
+    prefix="/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics",
+)
+
+
+@router.post(
+    "/{fabric_name}/{template_name}",
+    response_model=FabricResponseModel,
+    description="(v1) Create a fabric.",
+)
+def v1_fabric_post(
+    *,
+    session: Session = Depends(get_session),
+    fabric_name: str,
+    template_name: str,
+    fabric: FabricCreate,
+):
+    """
+    # Summary
+
+    POST request handler
+    """
+    db_fabric = Fabric.model_validate(fabric)
+    setattr(db_fabric, "FABRIC_NAME", fabric_name)
+    setattr(db_fabric, "FF", template_name)
+
+    session.add(db_fabric)
+    try:
+        session.commit()
+    except Exception as error:
+        # print(f"Error: {error}")
+        session.rollback()
+        msg = f"ND Site with name {fabric_name} already exists."
+        raise HTTPException(status_code=500, detail=msg) from error
+    session.refresh(db_fabric)
+    response = build_response(db_fabric)
+    return response


### PR DESCRIPTION
closes #26 

# Summary

Refactor  the router for the following endpoint:

Verb: POST
Path: `/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics//fabric_name}/{template_name}`

## Move endpoint handler to a new file in a directory aligned with NDFC endpoint path

v1/endpoints/lan_fabric/rest/config/fabrics/fabric_post.py

## ./app/main.py

- Update imports
- Add app.include_router(fabric_post.router, tags=["Fabrics (v1)"])

## ./app/v1/endpoints/fabric.py

- v1_post_fabric() - Remove old fabric_get handler