### PR TITLE
rest.control.fabrics.inventory: Refactor routers

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -6,7 +6,7 @@ from .v1.endpoints.configtemplate.rest.config.templates import config_template_b
 from .v1.endpoints.fm.about import version_get
 from .v1.endpoints.fm.features import features_get
 from .v1.endpoints.lan_fabric.rest.control.fabrics import fabric_delete, fabric_get, fabric_post, fabric_put, fabrics_get
-from .v1.endpoints.lan_fabric.rest.control.fabrics.inventory import v1_get_inventory_switches_by_fabric, v1_post_inventory_discover
+from .v1.endpoints.lan_fabric.rest.control.fabrics.inventory import discover_post, switches_by_fabric_get
 from .v1.endpoints.lan_fabric.rest.control.switches import fabric_name_get, overview
 from .v1.endpoints.lan_fabric.rest.control.switches.overview import v1_lan_fabric_rest_control_switches_overview_by_fabric_name
 from .v1.endpoints.lan_fabric.rest.control.switches.roles import roles_get, roles_post
@@ -21,6 +21,8 @@ app.include_router(fabrics_get.router, tags=["Fabrics (v1)"])
 app.include_router(features_get.router, tags=["Feature Manager (v1)"])
 app.include_router(version_get.router, tags=["Feature Manager (v1)"])
 app.include_router(version_get_internal.router, tags=["Internal (v1)"])
+app.include_router(discover_post.router, tags=["Inventory (v1)"])
+app.include_router(switches_by_fabric_get.router, tags=["Inventory (v1)"])
 app.include_router(roles_get.router, tags=["Inventory (v1)"])
 app.include_router(roles_post.router, tags=["Inventory (v1)"])
 app.include_router(fabric_name_get.router, tags=["Switches (v1)"])

--- a/app/v1/endpoints/lan_fabric/rest/control/fabrics/inventory/discover_post.py
+++ b/app/v1/endpoints/lan_fabric/rest/control/fabrics/inventory/discover_post.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python
+import copy
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlmodel import Session, select
+
+from ........db import get_session
+from .......models.fabric import Fabric
+from .......models.inventory import SwitchDbModel, SwitchDiscoverBodyModel, SwitchDiscoverItem
+
+router = APIRouter(
+    prefix="/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics",
+)
+
+
+def build_db_switch(switch: SwitchDiscoverItem, db_fabric: Fabric) -> SwitchDbModel:
+    """
+    # Summary
+
+    Given a  SwitchDiscoverBodyModel and a Fabric model,
+    return a populated SwitchDbModel object.
+    """
+    return SwitchDbModel(
+        activeSupSlot=1,
+        availPorts=48,
+        ccStatus="",
+        cfsSyslogStatus=0,
+        colDBId=0,
+        connUnitStatus=0,
+        consistencyState=True,
+        contact="",
+        cpuUsage=0,
+        deviceType="Switch_Fabric",
+        displayHdrs="",
+        displayValues="",
+        domain="",
+        domainID=0,
+        elementType="",
+        fabricId=db_fabric.id,
+        fabricName=db_fabric.FABRIC_NAME,
+        fabricTechnology=db_fabric.FF,
+        fcoeEnabled=False,
+        fex=False,
+        fid=0,
+        freezeMode="",
+        health=0,
+        hostName=switch.sysName,
+        index=0,
+        intentedpeerName="",
+        interfaces="",
+        ipAddress=switch.ipaddr,
+        ipDomain="",
+        isEchSupport=False,
+        isLan=False,
+        isNonNexus=False,
+        isPmCollect=False,
+        isSharedBorder=False,
+        isTrapDelayed=False,
+        isVpcConfigured=False,
+        is_smlic_enabled=False,
+        keepAliveState="",
+        lastScanTime=0,
+        licenseDetail="",
+        licenseViolation=False,
+        linkName="",
+        logicalName=switch.sysName,
+        managable=True,
+        mds=False,
+        membership="",
+        mgmtAddress="",
+        memoryUsage=0,
+        mode="Normal",
+        model="",
+        moduleIndexOffset=9999,
+        modelType=0,
+        name=switch.sysName,
+        npvEnabled=False,
+        numberOfPorts=48,
+        operMode=None,
+        operStatus="Minor",
+        peer="",
+        peerlinkState="",
+        peerSerialNumber="",
+        peerSwitchDbId=0,
+        ports=0,
+        present=True,
+        primaryIP="",
+        primarySwitchDbID=0,
+        principal="",
+        protoDiscSettings="",
+        recvIntf="",
+        release=switch.version,
+        role="",
+        sanAnalyticsCapable=False,
+        scope="",
+        secondaryIP="",
+        secondarySwitchDbID=0,
+        sendIntf="",
+        serialNumber=switch.serial_number,
+        sharedBorder=False,
+        sourceInterface="mgmt0",
+        sourceVrf="management",
+        standbySupState=0,
+        status="",
+        switchDbID=None,
+        swType="",
+        swUUID="DCNM-UUID-TEMP",
+        swUUIDId=99999,
+        swWwn="",
+        swWwnName="",
+        sysDescr="",
+        systemMode=None,
+        uid=0,
+        unmanagableCause="",
+        upTime=0,
+        upTimeNumber=0,
+        upTimeStr="",
+        usedPorts=0,
+        username="",
+        vdcId=0,
+        vdcName="",
+        vdcMac="",
+        vendor="cisco",
+        version=switch.version,
+        vpcDomain=0,
+        vrf="management",
+        vsanWwn="",
+        vsanWwnName="",
+        waitForSwitchModeChg=False,
+        wwn="",
+    )
+
+
+def build_success_response():
+    """
+    # Summary
+
+    Build a 200 response body for a successful operation.
+
+    ## Notes
+
+    """
+    response = {"status": "Success"}
+    return copy.deepcopy(response)
+
+
+@router.post("/{fabric_name}/inventory/discover")
+def v1_inventory_discover_post(*, session: Session = Depends(get_session), fabric_name: str, switch_discovery_body: SwitchDiscoverBodyModel):
+    """
+    # Summary
+
+    Discover switches for a given fabric_name.
+
+    ## Endpoint
+
+    ### Verb
+
+    POST
+
+    ### Path
+
+    /appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{fabric_name}/inventory/discover
+    """
+    db_fabric = session.exec(select(Fabric).where(Fabric.FABRIC_NAME == fabric_name)).first()
+    if not db_fabric:
+        raise HTTPException(status_code=404, detail=f"Fabric {fabric_name} not found")
+    fabric_id = db_fabric.id
+    db_switches = session.exec(select(SwitchDbModel).where(SwitchDbModel.fabricId == fabric_id)).all()
+    for db_switch in db_switches:
+        if db_switch.serialNumber in [discovery_body.serial_number for discovery_body in switch_discovery_body.switches]:
+            raise HTTPException(status_code=500, detail=f"Switch {db_switch.serialNumber} already exists in fabric {fabric_name}")
+    for discovery_body in switch_discovery_body.switches:
+        db_switch = build_db_switch(discovery_body, db_fabric)
+        session.add(db_switch)
+    session.commit()
+    response = build_success_response()
+    return response

--- a/app/v1/endpoints/lan_fabric/rest/control/fabrics/inventory/switches_by_fabric_get.py
+++ b/app/v1/endpoints/lan_fabric/rest/control/fabrics/inventory/switches_by_fabric_get.py
@@ -2,13 +2,16 @@
 import copy
 from typing import List
 
-from fastapi import Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from sqlmodel import Session, select
 
-from .......app import app
-from .......db import get_session
-from ......models.fabric import Fabric
-from ......models.inventory import SwitchDbModel, SwitchDiscoverBodyModel, SwitchDiscoverItem, SwitchResponseModel
+from ........db import get_session
+from .......models.fabric import Fabric
+from .......models.inventory import SwitchDbModel, SwitchResponseModel
+
+router = APIRouter(
+    prefix="/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics",
+)
 
 
 def build_response_switch(db_switch: SwitchDbModel) -> SwitchResponseModel:
@@ -134,124 +137,6 @@ def build_response_switch(db_switch: SwitchDbModel) -> SwitchResponseModel:
     )
 
 
-def build_db_switch(switch: SwitchDiscoverItem, db_fabric: Fabric) -> SwitchDbModel:
-    """
-    # Summary
-
-    Given a  SwitchDiscoverBodyModel and a Fabric model,
-    return a populated SwitchDbModel object.
-    """
-    return SwitchDbModel(
-        activeSupSlot=1,
-        availPorts=48,
-        ccStatus="",
-        cfsSyslogStatus=0,
-        colDBId=0,
-        connUnitStatus=0,
-        consistencyState=True,
-        contact="",
-        cpuUsage=0,
-        deviceType="Switch_Fabric",
-        displayHdrs="",
-        displayValues="",
-        domain="",
-        domainID=0,
-        elementType="",
-        fabricId=db_fabric.id,
-        fabricName=db_fabric.FABRIC_NAME,
-        fabricTechnology=db_fabric.FF,
-        fcoeEnabled=False,
-        fex=False,
-        fid=0,
-        freezeMode="",
-        health=0,
-        hostName=switch.sysName,
-        index=0,
-        intentedpeerName="",
-        interfaces="",
-        ipAddress=switch.ipaddr,
-        ipDomain="",
-        isEchSupport=False,
-        isLan=False,
-        isNonNexus=False,
-        isPmCollect=False,
-        isSharedBorder=False,
-        isTrapDelayed=False,
-        isVpcConfigured=False,
-        is_smlic_enabled=False,
-        keepAliveState="",
-        lastScanTime=0,
-        licenseDetail="",
-        licenseViolation=False,
-        linkName="",
-        logicalName=switch.sysName,
-        managable=True,
-        mds=False,
-        membership="",
-        mgmtAddress="",
-        memoryUsage=0,
-        mode="Normal",
-        model="",
-        moduleIndexOffset=9999,
-        modelType=0,
-        name=switch.sysName,
-        npvEnabled=False,
-        numberOfPorts=48,
-        operMode=None,
-        operStatus="Minor",
-        peer="",
-        peerlinkState="",
-        peerSerialNumber="",
-        peerSwitchDbId=0,
-        ports=0,
-        present=True,
-        primaryIP="",
-        primarySwitchDbID=0,
-        principal="",
-        protoDiscSettings="",
-        recvIntf="",
-        release=switch.version,
-        role="",
-        sanAnalyticsCapable=False,
-        scope="",
-        secondaryIP="",
-        secondarySwitchDbID=0,
-        sendIntf="",
-        serialNumber=switch.serial_number,
-        sharedBorder=False,
-        sourceInterface="mgmt0",
-        sourceVrf="management",
-        standbySupState=0,
-        status="",
-        switchDbID=None,
-        swType="",
-        swUUID="DCNM-UUID-TEMP",
-        swUUIDId=99999,
-        swWwn="",
-        swWwnName="",
-        sysDescr="",
-        systemMode=None,
-        uid=0,
-        unmanagableCause="",
-        upTime=0,
-        upTimeNumber=0,
-        upTimeStr="",
-        usedPorts=0,
-        username="",
-        vdcId=0,
-        vdcName="",
-        vdcMac="",
-        vendor="cisco",
-        version=switch.version,
-        vpcDomain=0,
-        vrf="management",
-        vsanWwn="",
-        vsanWwnName="",
-        waitForSwitchModeChg=False,
-        wwn="",
-    )
-
-
 def build_success_response():
     """
     # Summary
@@ -265,17 +150,25 @@ def build_success_response():
     return copy.deepcopy(response)
 
 
-@app.get(
-    "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{fabric_name}/inventory/switchesByFabric",
+@router.get(
+    "/{fabric_name}/inventory/switchesByFabric",
     response_model=List[SwitchResponseModel],
 )
-def v1_get_inventory_switches_by_fabric(*, session: Session = Depends(get_session), fabric_name: str):
+def v1_inventory_switches_by_fabric_get(*, session: Session = Depends(get_session), fabric_name: str):
     """
     # Summary
 
-    GET request handler with fabric_name as path parameter.
+    Return a list of switches hosted in fabric_name.
 
-    Return a list of switches for a given fabric_name.
+    ## Endpoint
+
+    ### Verb
+
+    GET
+
+    ### Path
+
+    /appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{fabric_name}/inventory/switchesByFabric
     """
     db_fabric = session.exec(select(Fabric).where(Fabric.FABRIC_NAME == fabric_name)).first()
     if not db_fabric:
@@ -285,29 +178,4 @@ def v1_get_inventory_switches_by_fabric(*, session: Session = Depends(get_sessio
     if len(db_switches) == 0:
         raise HTTPException(status_code=404, detail=f"No switches found for fabric {fabric_name}")
     response = [build_response_switch(db_switch) for db_switch in db_switches]
-    return response
-
-
-@app.post("/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{fabric_name}/inventory/discover")
-def v1_post_inventory_discover(*, session: Session = Depends(get_session), fabric_name: str, switch_discovery_body: SwitchDiscoverBodyModel):
-    """
-    # Summary
-
-    POST request handler with fabric_name as path parameter.
-
-    Discover switches for a given fabric_name.
-    """
-    db_fabric = session.exec(select(Fabric).where(Fabric.FABRIC_NAME == fabric_name)).first()
-    if not db_fabric:
-        raise HTTPException(status_code=404, detail=f"Fabric {fabric_name} not found")
-    fabric_id = db_fabric.id
-    db_switches = session.exec(select(SwitchDbModel).where(SwitchDbModel.fabricId == fabric_id)).all()
-    for db_switch in db_switches:
-        if db_switch.serialNumber in [discovery_body.serial_number for discovery_body in switch_discovery_body.switches]:
-            raise HTTPException(status_code=500, detail=f"Switch {db_switch.serialNumber} already exists in fabric {fabric_name}")
-    for discovery_body in switch_discovery_body.switches:
-        db_switch = build_db_switch(discovery_body, db_fabric)
-        session.add(db_switch)
-    session.commit()
-    response = build_success_response()
     return response


### PR DESCRIPTION
closes #41 

# Summary

Refactor  the routers for the following endpoints:

Verb: GET
Path: `/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{fabric_name}/inventory/switchesByFabric`

Verb: POST
Path: `/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{fabric_name}/inventory/discover`

## Move endpoint handlers

Move handlers to a directory aligned with NDFC endpoint paths

- v1/endpoints/lan_fabric/rest/control/fabrics/inventory/switches_by_fabric_get.py
- v1/endpoints/lan_fabric/rest/control/fabrics/inventory/discover_post.py

## ./app/main.py

- Update imports
- Add routers to app
  - app.include_router(discover_post.router, tags=["Inventory (v1)"])
  - app.include_router(switches_by_fabric_get.router, tags=["Inventory (v1)"])

## Remove unused file(s)

- v1/endpoints/lan_fabric/rest/control/fabrics/inventory.py