### PR TITLE
inventory.rediscover: Add endpoint handler

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -6,7 +6,7 @@ from .v1.endpoints.configtemplate.rest.config.templates import config_template_b
 from .v1.endpoints.fm.about import version_get
 from .v1.endpoints.fm.features import features_get
 from .v1.endpoints.lan_fabric.rest.control.fabrics import fabric_delete, fabric_get, fabric_post, fabric_put, fabrics_get
-from .v1.endpoints.lan_fabric.rest.control.fabrics.inventory import discover_post, internal_inventory_get, switches_by_fabric_get, test_reachability_post
+from .v1.endpoints.lan_fabric.rest.control.fabrics.inventory import discover_post, internal_inventory_get, rediscover_post, switches_by_fabric_get, test_reachability_post
 from .v1.endpoints.lan_fabric.rest.control.switches import fabric_name_get, overview
 from .v1.endpoints.lan_fabric.rest.control.switches.overview import v1_lan_fabric_rest_control_switches_overview_by_fabric_name
 from .v1.endpoints.lan_fabric.rest.control.switches.roles import roles_get, roles_post
@@ -27,6 +27,7 @@ app.include_router(switches_by_fabric_get.router, tags=["Inventory (v1)"])
 app.include_router(roles_get.router, tags=["Inventory (v1)"])
 app.include_router(roles_post.router, tags=["Inventory (v1)"])
 app.include_router(test_reachability_post.router, tags=["Inventory (v1)"])
+app.include_router(rediscover_post.router, tags=["Inventory (v1)"])
 app.include_router(fabric_name_get.router, tags=["Switches (v1)"])
 app.include_router(overview.router, tags=["Switches (v1)"])
 app.include_router(config_template_by_name.router, tags=["Templates (v1)"])

--- a/app/v1/endpoints/lan_fabric/rest/control/fabrics/inventory/rediscover_post.py
+++ b/app/v1/endpoints/lan_fabric/rest/control/fabrics/inventory/rediscover_post.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlmodel import Session, select
+
+from ........db import get_session
+from .......models.fabric import Fabric
+from .......models.inventory import SwitchDbModel
+
+router = APIRouter(
+    prefix="/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics",
+)
+
+
+def build_success_response():
+    """
+    # Summary
+
+    Build a 200 response body for a successful operation.
+
+    ## Notes
+
+    """
+    return {"status": "Success"}
+
+
+@router.post("/{fabric_name}/inventory/rediscover/{serial_number}")
+def v1_inventory_rediscover_post(*, session: Session = Depends(get_session), fabric_name: str, serial_number: str):
+    """
+    # Summary
+
+    Rediscover a switch in fabric fabric_name with serial number serial_number.
+
+    ## Endpoint
+
+    ### Verb
+
+    POST
+
+    ### Path
+
+    /appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{fabric_name}/inventory/discover/{serial_number}
+    """
+    db_fabric = session.exec(select(Fabric).where(Fabric.FABRIC_NAME == fabric_name)).first()
+    if not db_fabric:
+        raise HTTPException(status_code=404, detail=f"Fabric {fabric_name} not found")
+    fabric_id = db_fabric.id
+    db_switch = session.exec(select(SwitchDbModel).where(SwitchDbModel.fabricId == fabric_id).where(SwitchDbModel.serialNumber == serial_number)).first()
+    if not db_switch:
+        raise HTTPException(status_code=500, detail=f"Invalid Serial Number or IP address. serialNumber={serial_number}")
+    db_switch.status = "ok"
+    session.add(db_switch)
+    session.commit()
+    return build_success_response()

--- a/app/v1/models/inventory.py
+++ b/app/v1/models/inventory.py
@@ -159,13 +159,13 @@ class SwitchDbModel(SwitchBase, table=True):
 
 class SwitchDiscoverItem(BaseModel):
     """
-    Representation of a switch in a discovery.
+    Representation of a switch in a SwitchDiscoverBodyModel.
     """
 
     model_config = ConfigDict(use_enum_values=True)
 
     deviceIndex: str
-    serial_number: str
+    serialNumber: str
     sysName: str
     platform: str
     version: str


### PR DESCRIPTION
closes #47 

# Summary

Add handler for the following NDFC endpoint:

Verb: POST
Path: `/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{fabric_name}/inventory/rediscover/{serial_number}`

## Endpoint handler

- v1/endpoints/lan_fabric/rest/control/fabrics/inventory/rediscover_post.py

## ./app/main.py

- Update imports
- app.include_router(rediscover_post.router, tags=["Inventory (v1)"])

## ./app/v1/models/inventory.py

- Fix serialNumber parameter in SwitchDiscoverItem

This was serial_number, but needs to be serialNumber