### PR TITLE
Lan config.get lan switch credentials with type

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -10,9 +10,12 @@ from .v1.endpoints.lan_fabric.rest.control.fabrics.inventory import discover_pos
 from .v1.endpoints.lan_fabric.rest.control.switches import fabric_name_get, overview
 from .v1.endpoints.lan_fabric.rest.control.switches.overview import v1_lan_fabric_rest_control_switches_overview_by_fabric_name
 from .v1.endpoints.lan_fabric.rest.control.switches.roles import roles_get, roles_post
+from .v1.endpoints.lan_fabric.rest.lanConfig import getLanSwitchCredentialsWithType
 from .v1.endpoints.login import post_login
 from .v2.endpoints.fabric import v2_delete_fabric, v2_get_fabric_by_fabric_name, v2_get_fabrics, v2_post_fabric, v2_put_fabric
 
+
+app.include_router(getLanSwitchCredentialsWithType.router, tags=["Credentials (v1)"])
 app.include_router(fabric_delete.router, tags=["Fabrics (v1)"])
 app.include_router(fabric_get.router, tags=["Fabrics (v1)"])
 app.include_router(fabric_post.router, tags=["Fabrics (v1)"])

--- a/app/main.py
+++ b/app/main.py
@@ -14,7 +14,6 @@ from .v1.endpoints.lan_fabric.rest.lanConfig import getLanSwitchCredentialsWithT
 from .v1.endpoints.login import post_login
 from .v2.endpoints.fabric import v2_delete_fabric, v2_get_fabric_by_fabric_name, v2_get_fabrics, v2_post_fabric, v2_put_fabric
 
-
 app.include_router(getLanSwitchCredentialsWithType.router, tags=["Credentials (v1)"])
 app.include_router(fabric_delete.router, tags=["Fabrics (v1)"])
 app.include_router(fabric_get.router, tags=["Fabrics (v1)"])

--- a/app/v1/endpoints/lan_fabric/rest/lanConfig/getLanSwitchCredentialsWithType.py
+++ b/app/v1/endpoints/lan_fabric/rest/lanConfig/getLanSwitchCredentialsWithType.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python
+
+from typing import List
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+from sqlmodel import Session, select
+
+from ......db import get_session
+from .....models.fabric import Fabric
+from .....models.inventory import SwitchDbModel
+
+router = APIRouter(
+    prefix="/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/lanConfig",
+)
+
+
+class GetLanSwitchCredentialsWithTypeItem(BaseModel):
+    """
+    # Summary
+
+    A response model for the getLanSwitchCredentialsWithType endpoint.
+
+    ```json
+    {
+        "credType": "Robot",
+        "groupName": "F1",
+        "ipAddress": "172.22.150.107",
+        "sshPassword": "*****",
+        "sshUserName": "admin",
+        "switchDbID": "27470",
+        "switchName": "cvd-2312-leaf",
+        "v3Protocol": "0"
+    }
+    ```
+    """
+
+    credType: str
+    groupName: str
+    ipAddress: str
+    sshPassword: str
+    sshUserName: str
+    switchDbID: str
+    switchName: str
+    v3Protocol: str
+
+
+def build_success_response(db_switch, db_fabric) -> GetLanSwitchCredentialsWithTypeItem:
+    """
+    # Summary
+
+    Build a 200 response body for a successful operation.
+
+    ## Notes
+
+    """
+    return GetLanSwitchCredentialsWithTypeItem(
+        credType="Robot",
+        groupName=db_fabric.FABRIC_NAME,
+        ipAddress=db_switch.ipAddress,
+        sshPassword="*****",
+        sshUserName="admin",
+        switchDbID=str(db_switch.switchDbID),
+        switchName=db_switch.hostName,
+        v3Protocol="0",
+    )
+
+
+@router.get("/getLanSwitchCredentialsWithType")
+def v1_getLanSwitchCredentialsWithType(*, session: Session = Depends(get_session)) -> List[GetLanSwitchCredentialsWithTypeItem | None]:
+    """
+    # Summary
+
+    Get LAN Switch credentials.
+
+    ## Endpoint
+
+    ### Verb
+
+    GET
+
+    ### Path
+    /appcenter/cisco/ndfc/api/v1/lan-fabric/rest/lanConfig/getLanSwitchCredentialsWithType
+    """
+    db_fabric = session.exec(select(Fabric)).first()
+    if not db_fabric:
+        return []
+    fabric_id = db_fabric.id
+    db_switch = session.exec(select(SwitchDbModel).where(SwitchDbModel.fabricId == fabric_id)).first()
+    if not db_switch:
+        return []
+    return [build_success_response(db_switch, db_fabric)]


### PR DESCRIPTION
closes #49 

# Summary

Add handler for the following NDFC endpoint:

Verb: GET
Path: `/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/lanConfig/getLanSwitchCredentialsWithType`

## Endpoint handler

- v1/endpoints/lan_fabric/rest/lanConfig/getLanSwitchCredentialsWithType.py

## ./app/main.py

- Update imports
app.include_router(getLanSwitchCredentialsWithType.router, tags=["Credentials (v1)"])

