### PR TITLE
Fix prior merge breakage using stashed copies

### DIFF
--- a/app/common/functions/utilities.py
+++ b/app/common/functions/utilities.py
@@ -1,10 +1,51 @@
+import random
+import string
 from datetime import datetime
 
 
-def get_datetime():
+def get_datetime() -> datetime:
     """
     We specifically do NOT want to store timezone info
     in the datetime object since we don't need it.  Rather,
     we are treating datetime like a timestamp.
     """
     return datetime.now().replace(tzinfo=None)
+
+
+def gen_hex(length) -> str:
+    """
+    Generate a random hex string of length `length`.
+    """
+    return "".join(random.choice("0123456789ABCDEF") for _ in range(length))
+
+
+def gen_number(length) -> str:
+    """
+    Generate a random number of length `length`.
+    """
+    return "".join(random.choice("0123456789") for _ in range(length))
+
+
+def gen_string(length) -> str:
+    """
+    Generate a random alphabetic string of length `length`.
+    """
+    return "".join(random.choice(string.ascii_letters) for _ in range(length))
+
+
+def random_unicast_mac_address() -> str:
+    """
+    Generate a random unicast MAC address, with an OUI of 00:AA:BB.
+    """
+    return f"00:AA:BB:{gen_hex(2)}:{gen_hex(2)}:{gen_hex(2)}"
+
+
+def random_switch_serial_number() -> str:
+    """
+    # Summary
+
+    Generate a random switch serial number.
+
+    FOX2109PGCS
+    """
+    return f"FOX{gen_number(4)}{gen_string(4).upper()}"

--- a/app/main.py
+++ b/app/main.py
@@ -10,7 +10,7 @@ from .v1.endpoints.lan_fabric.rest.control.fabrics.inventory import discover_pos
 from .v1.endpoints.lan_fabric.rest.control.switches import fabric_name_get, overview
 from .v1.endpoints.lan_fabric.rest.control.switches.overview import v1_lan_fabric_rest_control_switches_overview_by_fabric_name
 from .v1.endpoints.lan_fabric.rest.control.switches.roles import roles_get, roles_post
-from .v1.endpoints.lan_fabric.rest.lanConfig import getLanSwitchCredentialsWithType
+from .v1.endpoints.lan_fabric.rest.lanConfig import getLanSwitchCredentialsWithType, internal_getLanSwitchCredentials
 from .v1.endpoints.login import post_login
 from .v2.endpoints.fabric import v2_delete_fabric, v2_get_fabric_by_fabric_name, v2_get_fabrics, v2_post_fabric, v2_put_fabric
 
@@ -24,6 +24,7 @@ app.include_router(features_get.router, tags=["Feature Manager (v1)"])
 app.include_router(version_get.router, tags=["Feature Manager (v1)"])
 app.include_router(version_get_internal.router, tags=["Internal (v1)"])
 app.include_router(internal_inventory_get.router, tags=["Internal (v1)"])
+app.include_router(internal_getLanSwitchCredentials.router, tags=["Internal (v1)"])
 app.include_router(discover_post.router, tags=["Inventory (v1)"])
 app.include_router(switches_by_fabric_get.router, tags=["Inventory (v1)"])
 app.include_router(roles_get.router, tags=["Inventory (v1)"])

--- a/app/v1/endpoints/lan_fabric/rest/control/fabrics/inventory/internal_inventory_get.py
+++ b/app/v1/endpoints/lan_fabric/rest/control/fabrics/inventory/internal_inventory_get.py
@@ -177,5 +177,4 @@ def v1_inventory_switches_by_fabric_get(*, session: Session = Depends(get_sessio
     db_switches = session.exec(select(SwitchDbModel).where(SwitchDbModel.fabricId == fabric_id)).all()
     if len(db_switches) == 0:
         return []
-    response = [build_response_switch(db_switch) for db_switch in db_switches]
-    return response
+    return [build_response_switch(db_switch) for db_switch in db_switches]

--- a/app/v1/endpoints/lan_fabric/rest/control/fabrics/inventory/switches_by_fabric_get.py
+++ b/app/v1/endpoints/lan_fabric/rest/control/fabrics/inventory/switches_by_fabric_get.py
@@ -176,6 +176,5 @@ def v1_inventory_switches_by_fabric_get(*, session: Session = Depends(get_sessio
     fabric_id = db_fabric.id
     db_switches = session.exec(select(SwitchDbModel).where(SwitchDbModel.fabricId == fabric_id)).all()
     if len(db_switches) == 0:
-        raise HTTPException(status_code=404, detail=f"No switches found for fabric {fabric_name}")
-    response = [build_response_switch(db_switch) for db_switch in db_switches]
-    return response
+        return []
+    return [build_response_switch(db_switch) for db_switch in db_switches]

--- a/app/v1/endpoints/lan_fabric/rest/lanConfig/internal_getLanSwitchCredentials.py
+++ b/app/v1/endpoints/lan_fabric/rest/lanConfig/internal_getLanSwitchCredentials.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python
+
+from typing import List
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+from sqlmodel import Session, select
+
+from ......db import get_session
+from .....models.fabric import Fabric
+from .....models.inventory import SwitchDbModel
+
+router = APIRouter(
+    prefix="/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/lanConfig",
+)
+
+
+class GetLanSwitchCredentialsItem(BaseModel):
+    """
+    # Summary
+
+    A response model for the getLanSwitchCredentialsWithType endpoint.
+
+    ```json
+    {
+        "credType": "Robot",
+        "groupName": "F1",
+        "ipAddress": "172.22.150.107",
+        "sshPassword": "*****",
+        "sshUserName": "admin",
+        "switchDbID": "27470",
+        "switchName": "cvd-2312-leaf",
+        "v3Protocol": "0"
+    }
+    ```
+    """
+
+    credType: str
+    groupName: str
+    ipAddress: str
+    sshPassword: str
+    sshUserName: str
+    switchDbID: str
+    switchName: str
+    v3Protocol: str
+
+
+def build_success_response(db_switch, db_fabric) -> GetLanSwitchCredentialsItem:
+    """
+    # Summary
+
+    Build a 200 response body for a successful operation.
+
+    ## Notes
+
+    """
+    return GetLanSwitchCredentialsItem(
+        credType="Robot",
+        groupName=db_fabric.FABRIC_NAME,
+        ipAddress=db_switch.ipAddress,
+        sshPassword="*****",
+        sshUserName="admin",
+        switchDbID=str(db_switch.switchDbID),
+        switchName=db_switch.hostName,
+        v3Protocol="0",
+    )
+
+
+@router.get("/getLanSwitchCredentials")
+def v1_getLanSwitchCredentials(*, session: Session = Depends(get_session)) -> List[GetLanSwitchCredentialsItem | None]:
+    """
+    # Summary
+
+    Get LAN Switch credentials.
+
+    This is an internal (unpublished) endpoint used by ansible-dcnm dcnm_inventory module.
+
+    Once we modify the ansible-dcnm dcnm_inventory module to use the new endpoint, we can
+    remove this endpoint handler.
+
+    ## Endpoint
+
+    ### Verb
+
+    GET
+
+    ### Path
+    /appcenter/cisco/ndfc/api/v1/lan-fabric/rest/lanConfig/getLanSwitchCredentials
+    """
+    db_fabric = session.exec(select(Fabric)).first()
+    if not db_fabric:
+        return []
+    fabric_id = db_fabric.id
+    db_switch = session.exec(select(SwitchDbModel).where(SwitchDbModel.fabricId == fabric_id)).first()
+    if not db_switch:
+        return []
+    return [build_success_response(db_switch, db_fabric)]


### PR DESCRIPTION
A few commits ago, we had a merge breakage that resulted in multiple files being changed.

This commit restores those files (for the most part) from from a couple stashes.

It also adds an endpoint handler for two more internal (unpublished) NDFC endpoint:

GET /appcenter/cisco/ndfc/api/v1/lan-fabric/rest/lanConfig/getLanSwitchCredentials

GET /appcenter/cisco/ndfc/api/v1/lan-fabric/rest/lanConfig/getLanSwitchCredentials