### PR TITLE
manage.fabrics.fabric_get: refactor router, more...

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -12,11 +12,13 @@ from .v1.endpoints.lan_fabric.rest.control.switches import fabric_name_get, over
 from .v1.endpoints.lan_fabric.rest.control.switches.overview import v1_lan_fabric_rest_control_switches_overview_by_fabric_name
 from .v1.endpoints.lan_fabric.rest.control.switches.roles import roles_get, roles_post
 from .v1.endpoints.lan_fabric.rest.lanConfig import getLanSwitchCredentialsWithType, internal_getLanSwitchCredentials
-from .v2.endpoints.fabric import v2_get_fabric_by_fabric_name, v2_post_fabric, v2_put_fabric
+from .v2.endpoints.fabric import v2_post_fabric, v2_put_fabric
 from .v2.endpoints.manage.fabrics import fabric_delete as v2_fabric_delete
+from .v2.endpoints.manage.fabrics import fabric_get as v2_fabric_get
 from .v2.endpoints.manage.fabrics import fabrics_get as v2_fabrics_get
 
 app.include_router(v2_fabric_delete.router, tags=["Manage Fabrics (v2)"])
+app.include_router(v2_fabric_get.router, tags=["Manage Fabrics (v2)"])
 app.include_router(v2_fabrics_get.router, tags=["Manage Fabrics (v2)"])
 app.include_router(getLanSwitchCredentialsWithType.router, tags=["Credentials (v1)"])
 app.include_router(fabric_delete.router, tags=["Fabrics (v1)"])

--- a/app/v2/endpoints/fabric.py
+++ b/app/v2/endpoints/fabric.py
@@ -56,23 +56,6 @@ def build_db_fabric(fabric):
     return db_fabric
 
 
-@app.get(
-    "/api/v1/manage/fabrics/{fabric_name}",
-    response_model=FabricResponseModel,
-)
-def v2_get_fabric_by_fabric_name(*, session: Session = Depends(get_session), fabric_name: str):
-    """
-    # Summary
-
-    GET request handler with fabric_name as path parameter.
-    """
-    fabric = session.get(FabricDbModel, fabric_name)
-    if not fabric:
-        raise HTTPException(status_code=404, detail=f"Fabric {fabric_name} not found")
-    response = build_response(fabric)
-    return response
-
-
 @app.post("/api/v1/manage/fabrics", response_model=FabricResponseModel)
 async def v2_post_fabric(*, session: Session = Depends(get_session), fabric: FabricResponseModel):
     """

--- a/app/v2/endpoints/manage/fabrics/common.py
+++ b/app/v2/endpoints/manage/fabrics/common.py
@@ -1,0 +1,27 @@
+from pydantic import BaseModel
+
+
+class FabricLocationModel(BaseModel):
+    """
+    # Summary
+
+    The location of the fabric, represented by latitude and longitude.
+    """
+
+    latitude: float
+    longitude: float
+
+
+class FabricManagementModel(BaseModel):
+    """
+    # Summary
+
+    The management information for the fabric.
+
+    TODO: This model should be moved to a shared location and
+    include all parameters.  For now, we're supporting only
+    mandatory parameters for testing.
+    """
+
+    bgpAsn: str
+    type: str

--- a/app/v2/endpoints/manage/fabrics/fabrics_get.py
+++ b/app/v2/endpoints/manage/fabrics/fabrics_get.py
@@ -2,7 +2,6 @@ import copy
 from typing import Any, List
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from pydantic import BaseModel
 from sqlmodel import Session, select
 
 from .....db import get_session

--- a/docs/supported_endpoints.md
+++ b/docs/supported_endpoints.md
@@ -6,27 +6,27 @@
 
 ## Default
 
-- `/api/v1/manage/fabrics/{fabric_name}`
-  - `get`
-    - V2 Get Fabric By Fabric Name
+- `/api/v1/manage/fabrics`
+  - `post`
+    - V2 Post Fabric
 
 - `/api/v1/manage/fabrics/{fabric_name}`
   - `put`
     - V2 Put Fabric
 
-- `/api/v1/manage/fabrics`
-  - `post`
-    - V2 Post Fabric
-
 ## Manage Fabrics (v2)
+
+- `/api/v1/manage/fabrics`
+  - `get`
+    - V2 Fabrics Get
 
 - `/api/v1/manage/fabrics/{fabric_name}`
   - `delete`
     - V2 Delete Fabric
 
-- `/api/v1/manage/fabrics`
+- `/api/v1/manage/fabrics/{fabric_name}`
   - `get`
-    - V2 Fabrics Get
+    - V2 Fabric Get
 
 ## Credentials (v1)
 


### PR DESCRIPTION
1. app/main.py

- Update imports
- app.include_router(v2_fabric_get.router, tags=["Manage Fabrics (v2)"])

2. app/v2/endpoints/fabric.py

- Remove v2_get_fabric_by_fabric_name()

3. app/v2/endpoints/manage/fabrics/common.py

- FabricLocationModel added
- FabricManagementModel added

4. app/v2/endpoints/manage/fabrics/fabric_get.py

- New file
- Adds v2_fabric_get() to replace v2_get_fabric_by_fabric_name()

5. app/v2/endpoints/manage/fabrics/fabrics_get.py

- Remove FabricLocationModel and import from .common
- Remove FabricManagementModel and import from .common

6. docs/supported_endpoints.md

- Update documentation