### PR TITLE
lan_fabric.rest.topology.role_put - new endpoint

### DIFF
--- a/app/common/functions/utilities.py
+++ b/app/common/functions/utilities.py
@@ -49,3 +49,42 @@ def random_switch_serial_number() -> str:
     FOX2109PGCS
     """
     return f"FOX{gen_number(4)}{gen_string(4).upper()}"
+
+
+def map_friendly_switch_role_to_enum_key(role: str) -> str:
+    """
+    # Summary
+
+    Map a friendly switch role name to a key to use with
+    ../enums/switch.py SwitchRoleFriendlyEnum and SwitchRoleEnum.
+
+    For example:
+
+    "border gateway spine" -> "borderGatewaySpine"
+
+    # Parameters
+
+    - role: The switch role.
+
+    # Returns
+
+    The key to use with SwitchRoleFriendlyEnum and SwitchRoleEnum.
+    """
+    switch_role_map = {
+        "access": "access",
+        "aggregation": "aggregation",
+        "border": "border",
+        "border gateway": "borderGateway",
+        "border gateway spine": "borderGatewaySpine",
+        "border gateway super spine": "borderGatewaySuperSpine",
+        "border spine": "borderSpine",
+        "border super spine": "borderSuperSpine",
+        "core router": "coreRouter",
+        "edge router": "edgeRouter",
+        "leaf": "leaf",
+        "spine": "spine",
+        "super spine": "superSpine",
+        "tier2 leaf": "tier2Leaf",
+        "tor": "tor",
+    }
+    return switch_role_map[role]

--- a/app/main.py
+++ b/app/main.py
@@ -12,6 +12,7 @@ from .v1.endpoints.lan_fabric.rest.control.switches import fabric_name_get, over
 from .v1.endpoints.lan_fabric.rest.control.switches.overview import v1_lan_fabric_rest_control_switches_overview_by_fabric_name
 from .v1.endpoints.lan_fabric.rest.control.switches.roles import roles_get, roles_post
 from .v1.endpoints.lan_fabric.rest.lanConfig import getLanSwitchCredentialsWithType, internal_getLanSwitchCredentials
+from .v1.endpoints.lan_fabric.rest.topology import role_put as internal_role_put
 from .v2.endpoints.manage.fabrics import fabric_delete as v2_fabric_delete
 from .v2.endpoints.manage.fabrics import fabric_get as v2_fabric_get
 from .v2.endpoints.manage.fabrics import fabric_post as v2_fabric_post
@@ -33,6 +34,7 @@ app.include_router(features_get.router, tags=["Feature Manager (v1)"])
 app.include_router(version_get.router, tags=["Feature Manager (v1)"])
 app.include_router(version_get_internal.router, tags=["Internal (v1)"])
 app.include_router(internal_inventory_get.router, tags=["Internal (v1)"])
+app.include_router(internal_role_put.router, tags=["Internal (v1)"])
 app.include_router(internal_getLanSwitchCredentials.router, tags=["Internal (v1)"])
 app.include_router(discover_post.router, tags=["Inventory (v1)"])
 app.include_router(switches_by_fabric_get.router, tags=["Inventory (v1)"])

--- a/app/v1/endpoints/lan_fabric/rest/topology/role_put.py
+++ b/app/v1/endpoints/lan_fabric/rest/topology/role_put.py
@@ -1,0 +1,115 @@
+from enum import Enum
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlmodel import Session, select
+
+from ......common.enums.switch import SwitchRoleFriendlyEnum
+from ......common.functions.utilities import map_friendly_switch_role_to_enum_key
+from ......db import get_session
+from .....models.inventory import SwitchDbModel
+
+router = APIRouter(
+    prefix="/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/topology/role",
+)
+
+
+class InternalRoleResponseModel(BaseModel):
+    """
+    # Summary
+
+    The response body for a successful operation.
+    """
+
+    tierLevel: int
+    newRole: str
+
+
+class TierLevelEnum(Enum):
+    """
+    # Summary
+
+    The tier level for each switch role.
+    """
+
+    leaf: int = 3
+    spine: int = 2
+    borderGateway: int = 1
+    borderGatewaySpine: int = 2
+
+
+def build_success_response(switch_db: SwitchDbModel) -> dict[str, Any]:
+    """
+    # Summary
+
+    Build a 200 response body for a successful operation.
+
+    ## Response Body
+
+    ```json
+    {
+        "tierLevel": 3,
+        "newRole": "border gateway spine"
+    }    ```
+    """
+    response_model = InternalRoleResponseModel(tierLevel=TierLevelEnum[switch_db.switchRoleEnum].value, newRole=switch_db.switchRole)
+    return response_model.model_dump()
+
+
+def http_exception_400_invalid_switch(switch_db_id: int) -> HTTPException:
+    """
+    # Summary
+
+    Build a 400 response body for an invalid switch.
+
+    ## Response Body
+
+    ```json
+    {
+        "detail": "Invalid switchDbId. switchDbId=1"
+    }
+    ```
+    """
+    return HTTPException(status_code=400, detail=f"Invalid switchDbId. switchDbId={switch_db_id}")
+
+
+@router.put(
+    "/{switch_db_id}",
+    response_model=InternalRoleResponseModel,
+    description="(v1) Internal, change switch role.",
+)
+def v1_internal_role_put(
+    *,
+    session: Session = Depends(get_session),
+    switch_db_id: int,
+    newRole: str,
+):
+    """
+    # Summary
+
+    PUT request handler
+    """
+    role_from_query_param = newRole.replace("%20", " ").lower()
+    db_switch = session.exec(select(SwitchDbModel).where(SwitchDbModel.switchDbID == switch_db_id)).first()
+    if not db_switch:
+        raise http_exception_400_invalid_switch(switch_db_id)
+    try:
+        role_key = map_friendly_switch_role_to_enum_key(role_from_query_param)
+    except KeyError as error:
+        msg = f"Invalid role. role={newRole}. "
+        msg += "Maybe you need to replace spaces with %20? "
+        msg += "For example: border gateway spine -> border%20gateway%20spine"
+        raise HTTPException(status_code=400, detail=msg) from error
+    print(f"role_key: {role_key}, SwitchRoleFriendlyEnum[role_key]: {SwitchRoleFriendlyEnum[role_key].value}")
+    db_switch.switchRole = SwitchRoleFriendlyEnum[role_key].value
+    db_switch.switchRoleEnum = role_key
+    session.add(db_switch)
+    session.commit()
+    session.refresh(db_switch)
+    print(f"db_switch.switchRole: {db_switch.switchRole}")
+    print(f"db_switch.switchRoleEnum: {db_switch.switchRoleEnum}")
+    print(f"db_switch.switchDbID: {db_switch.switchDbID}")
+    print(f"db_switch.serialNumber: {db_switch.serialNumber}")
+    response = build_success_response(db_switch)
+    return response

--- a/docs/supported_endpoints.md
+++ b/docs/supported_endpoints.md
@@ -74,6 +74,10 @@
   - `get`
     - V1 Inventory Switches By Fabric Get
 
+- `/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/topology/role/{switch_db_id}`
+  - `put`
+    - V1 Internal Role Put
+
 - `/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/lanConfig/getLanSwitchCredentials`
   - `get`
     - V1 Getlanswitchcredentials
@@ -106,7 +110,7 @@
 
 ## Nexus Dashboard (v1)
 
-- `/login/`
+- `/login`
   - `post`
     - Login Post
 


### PR DESCRIPTION
Add NDFC internal endpoint currently needed by dcnm_inventory in the ansible-dcnm collection.

1. app/common/functions/utilities.py

- map_friendly_switch_role_to_enum_key()

2. app/main.py

- Update imports
- app.include_router(internal_role_put.router, tags=["Internal (v1)"])

3. app/v1/endpoints/lan_fabric/rest/topology/role_put.py

- Endpoint handler

4. docs/supported_endpoints.md

- Add documentation for endpoint
- `/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/topology/role/{switchDbId}`