### PR TITLE
fabrics.fabric_delete: leverage common.build_404_response()

### DIFF
--- a/app/v1/endpoints/lan_fabric/rest/control/fabrics/fabric_delete.py
+++ b/app/v1/endpoints/lan_fabric/rest/control/fabrics/fabric_delete.py
@@ -1,10 +1,9 @@
-import datetime
-
 from fastapi import APIRouter, Depends, HTTPException
 from sqlmodel import Session, select
 
 from .......db import get_session
 from ......models.fabric import Fabric
+from .common import build_404_response
 
 router = APIRouter(
     prefix="/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics",
@@ -16,25 +15,16 @@ def v1_fabric_delete(*, session: Session = Depends(get_session), fabric_name: st
     """
     # Summary
 
-    DELETE request handler
+    Fabric DELETE request handler
 
-    ## NDFC Response
+    ## Path
 
-    {
-        "timestamp": 1739842602937,
-        "status": 404,
-        "error": "Not Found",
-        "path": "/rest/control/fabrics/f2"
-    }
+    /appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{fabric_name}
     """
     db_fabric = session.exec(select(Fabric).where(Fabric.FABRIC_NAME == fabric_name)).first()
     if not db_fabric:
-        detail = {}
-        detail["timestamp"] = int(datetime.datetime.now().timestamp())
-        detail["status"] = 404
-        detail["error"] = "Not Found"
-        detail["path"] = f"/rest/control/fabrics/{fabric_name}"
-        raise HTTPException(status_code=404, detail=detail)
+        path = f"{router.prefix}/{fabric_name}"
+        raise HTTPException(status_code=404, detail=build_404_response(path))
     session.delete(db_fabric)
     session.commit()
     return {f"Fabric '{fabric_name}' is deleted successfully!"}


### PR DESCRIPTION
1. app/v1/endpoints/lan_fabric/rest/control/fabrics/fabric_delete.py

- Import build_404_response
- Remove datetime import
- Remove local code and use shared code