### PR TITLE
ut.fabrics: Update test_v1_fabric_delete_110

### DIFF
--- a/tests/unit/v1/test_v1_fabric.py
+++ b/tests/unit/v1/test_v1_fabric.py
@@ -284,18 +284,23 @@ def test_v1_fabric_delete_110(session: Session, client: TestClient):
 
     1. Attempt to delete a fabric that does not exist
 
-    Verify that fabric is deleted with 200 status_code.
+    Verify expected error response is returned.
+
+    ## Notes
+    -   NDFC returns a shorter path in the error response: /rest/control/fabrics/foo
+        Hence, we are using "in" rather than == in the assert.  Currently,
+        ndfc_mock returns the full path.
     """
     response = client.delete("/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/foo")
     fabric_in_db = session.get(Fabric, "foo")
-
     response_decode = response.json()
+    response_detail = response_decode.get("detail")
 
     assert response.status_code == 404
-    assert response_decode["detail"]["timestamp"] is not None
-    assert isinstance(response_decode["detail"]["timestamp"], int) is True
-    assert response_decode["detail"]["status"] == 404
-    assert response_decode["detail"]["error"] == "Not Found"
-    assert response_decode["detail"]["path"] == "/rest/control/fabrics/foo"
-
+    assert response_detail is not None
+    assert response_detail.get("timestamp") is not None
+    assert isinstance(response_detail.get("timestamp"), int) is True
+    assert response_detail.get("status") == 404
+    assert response_detail.get("error") == "Not Found"
+    assert response_detail.get("path") in "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/foo"
     assert fabric_in_db is None


### PR DESCRIPTION
1. tests/unit/v1/test_v1_fabric.py

- Update test case asserts to avoid KeyError (although we shouldn't see any)
- Update test case docstring
- Update path assert to accept the full path, rather than the partial path that NDFC returns