### PR TITLE
update_db_switch(): update model using switch.platform

### DIFF
--- a/app/v1/endpoints/lan_fabric/rest/control/fabrics/inventory/common.py
+++ b/app/v1/endpoints/lan_fabric/rest/control/fabrics/inventory/common.py
@@ -59,7 +59,7 @@ def build_db_switch(switch: SwitchDiscoverItem, db_fabric: FabricDbModelV1) -> S
         mgmtAddress="",
         memoryUsage=0,
         mode="Normal",
-        model="",
+        model=switch.platform,
         moduleIndexOffset=9999,
         modelType=0,
         name=switch.sysName,


### PR DESCRIPTION
1. app/v1/endpoints/lan_fabric/rest/control/fabrics/inventory/common.py

- update_db_switch() was not updating the model field.  Fixed.