### PR TITLE
Add endpoint handler for removing switch from a fabric, more...

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -8,7 +8,7 @@ from .v1.endpoints.fm.about import version_get
 from .v1.endpoints.fm.features import features_get
 from .v1.endpoints.lan_fabric.rest.control.fabrics import config_deploy_post, config_save_post, fabric_delete, fabric_get, fabric_post, fabric_put, fabrics_get
 from .v1.endpoints.lan_fabric.rest.control.fabrics.inventory import discover_post, internal_inventory_get, rediscover_post, switches_by_fabric_get, test_reachability_post
-from .v1.endpoints.lan_fabric.rest.control.switches import fabric_name_get, overview_get
+from .v1.endpoints.lan_fabric.rest.control.switches import fabric_name_get, overview_get, switch_remove
 from .v1.endpoints.lan_fabric.rest.control.switches.roles import roles_get, roles_post
 from .v1.endpoints.lan_fabric.rest.lanConfig import getLanSwitchCredentialsWithType, internal_getLanSwitchCredentials
 from .v1.endpoints.lan_fabric.rest.topology import role_put as internal_role_put
@@ -46,4 +46,5 @@ app.include_router(rediscover_post.router, tags=["Inventory (v1)"])
 app.include_router(login.router, tags=["Nexus Dashboard (v1)"])
 app.include_router(fabric_name_get.router, tags=["Switches (v1)"])
 app.include_router(overview_get.router, tags=["Switches (v1)"])
+app.include_router(switch_remove.router, tags=["Switches (v1)"])
 app.include_router(config_template_by_name.router, tags=["Templates (v1)"])

--- a/app/v1/endpoints/lan_fabric/rest/control/fabrics/inventory/discover_post.py
+++ b/app/v1/endpoints/lan_fabric/rest/control/fabrics/inventory/discover_post.py
@@ -136,6 +136,9 @@ def v1_inventory_discover_post(*, session: Session = Depends(get_session), fabri
         # For discovered switches, set their initial role to spine
         db_switch.switchRoleEnum = "spine"
         db_switch.switchRole = "spine"
+        db_switch.ccStatus = "In-Sync"
+        db_switch.operStatus = "Healthy"
+        db_switch.fabricId = fabric_id
         session.add(db_switch)
     session.commit()
     # Update the switch overview tables

--- a/app/v1/endpoints/lan_fabric/rest/control/switches/models/switch_overview.py
+++ b/app/v1/endpoints/lan_fabric/rest/control/switches/models/switch_overview.py
@@ -256,8 +256,8 @@ class SwitchOverviewHealth:
             if self.health == attribute:
                 setattr(record, attribute, getattr(record, attribute) + 1)
                 self.session.add(record)
+                self.session.commit()
                 break
-        self.session.commit()
 
     def delete(self):
         """
@@ -290,8 +290,8 @@ class SwitchOverviewHealth:
             if self.health == attribute and getattr(record, attribute) > 0:
                 setattr(record, attribute, getattr(record, attribute) - 1)
                 self.session.add(record)
+                self.session.commit()
                 break
-        self.session.commit()
 
     def response_dict(self) -> dict[str, Any]:
         """
@@ -467,23 +467,6 @@ class SwitchOverviewRoles:
             "super spine",
             "tor",
         }
-        self.external_to_db = {
-            "access": "access",
-            "aggregation": "aggregation",
-            "border": "border",
-            "border gateway": "border_gateway",
-            "border gateway spine": "border_gateway_spine",
-            "border gateway super spine": "border_gateway_super_spine",
-            "border spine": "border_spine",
-            "border super spine": "border_super_spine",
-            "core router": "core_router",
-            "edge router": "edge_router",
-            "leaf": "leaf",
-            "spine": "spine",
-            "super spine": "super_spine",
-            "tor": "tor",
-        }
-        self.db_to_external = {v: k for k, v in self.external_to_db.items()}
 
     def initialize_db_table(self):
         """
@@ -712,7 +695,7 @@ class SwitchOverviewSw:
         self._session = None
         self._model_init = SwitchSWVersionsDbModel(version_name="ignore", count=0)
 
-    def initialize_db_table(self):
+    def initialize_db_table(self) -> None:
         """
         Initializes the switch software versions database table.
         """
@@ -729,7 +712,7 @@ class SwitchOverviewSw:
         if commit:
             self.session.commit()
 
-    def validate_properties(self):
+    def validate_properties(self) -> None:
         """
         Validate the properties of the class.
         """
@@ -738,7 +721,7 @@ class SwitchOverviewSw:
         if self._session is None:
             raise ValueError("Session not set")
 
-    def add(self):
+    def add(self) -> None:
         """
         # Summary
 
@@ -761,10 +744,10 @@ class SwitchOverviewSw:
                 if record.version_name == self.version:
                     record.count += 1
                     self.session.add(record)
+                    self.session.commit()
                     break
-        self.session.commit()
 
-    def delete(self):
+    def delete(self) -> None:
         """
         # Summary
 
@@ -779,7 +762,7 @@ class SwitchOverviewSw:
             self.session.delete(record)
             self.session.commit()
 
-    def remove(self):
+    def remove(self) -> None:
         """
         # Summary
 
@@ -793,15 +776,18 @@ class SwitchOverviewSw:
 
         if self.version not in [record.version_name for record in records]:
             return
-
+        commit = False
         for record in records:
             if record.version_name == self.version and record.count > 0:
                 record.count -= 1
                 if record.count == 0:
+                    commit = True
                     self.session.delete(record)
                 else:
+                    commit = True
                     self.session.add(record)
-        self.session.commit()
+        if commit is True:
+            self.session.commit()
 
     def response_dict(self) -> dict:
         """
@@ -924,7 +910,7 @@ class SwitchOverviewHw:
         self._session = None
         self._model_init = SwitchHwDbModel(model="ignore", count=0)
 
-    def initialize_db_table(self):
+    def initialize_db_table(self) -> None:
         """
         Initializes the switch hardware versions database table.
         """
@@ -941,7 +927,7 @@ class SwitchOverviewHw:
         if commit:
             self.session.commit()
 
-    def validate_properties(self):
+    def validate_properties(self) -> None:
         """
         Validate the properties of the class.
         """
@@ -950,7 +936,7 @@ class SwitchOverviewHw:
         if self._session is None:
             raise ValueError("Session not set")
 
-    def add(self):
+    def add(self) -> None:
         """
         # Summary
 
@@ -973,10 +959,10 @@ class SwitchOverviewHw:
                 if record.model == self.model:
                     record.count += 1
                     self.session.add(record)
+                    self.session.commit()
                     break
-        self.session.commit()
 
-    def delete(self):
+    def delete(self) -> None:
         """
         # Summary
 
@@ -991,7 +977,7 @@ class SwitchOverviewHw:
             self.session.delete(record)
             self.session.commit()
 
-    def remove(self):
+    def remove(self) -> None:
         """
         # Summary
 
@@ -1006,14 +992,17 @@ class SwitchOverviewHw:
         if self.model not in [record.model for record in records]:
             return
 
+        commit = False
         for record in records:
             if record.model == self.model and record.count > 0:
                 record.count -= 1
+                commit = True
                 if record.count == 0:
                     self.session.delete(record)
                 else:
                     self.session.add(record)
-        self.session.commit()
+        if commit is True:
+            self.session.commit()
 
     def response_dict(self) -> dict:
         """
@@ -1045,7 +1034,7 @@ class SwitchOverviewHw:
                 response[record.model] = record.count
         return json.dumps(response)
 
-    def response_model(self) -> Sequence[SwitchHwDbModel] | None:
+    def response_model(self) -> Sequence[SwitchHwDbModel]:
         """
         Returns the current switch hardware model data for self.fabric as a model.
         """
@@ -1137,7 +1126,7 @@ class SwitchOverviewSync:
         self._model_init = SwitchConfigDbModel(in_sync=0, out_of_sync=0)
         self.attributes = {"in_sync", "out_of_sync"}
 
-    def initialize_db_table(self):
+    def initialize_db_table(self) -> None:
         """
         Initializes the switch configuration synchronization database table.
         """
@@ -1154,7 +1143,7 @@ class SwitchOverviewSync:
         if commit:
             self.session.commit()
 
-    def validate_properties(self):
+    def validate_properties(self) -> None:
         """
         Validate the properties of the class.
         """
@@ -1163,7 +1152,7 @@ class SwitchOverviewSync:
         if self._session is None:
             raise ValueError("Session not set")
 
-    def add(self):
+    def add(self) -> None:
         """
         # Summary
 
@@ -1179,10 +1168,10 @@ class SwitchOverviewSync:
             if attribute == self.sync:
                 setattr(record, attribute, getattr(record, attribute) + 1)
                 self.session.add(record)
+                self.session.commit()
                 break
-        self.session.commit()
 
-    def delete(self):
+    def delete(self) -> None:
         """
         # Summary
 
@@ -1197,7 +1186,7 @@ class SwitchOverviewSync:
             self.session.delete(record)
             self.session.commit()
 
-    def remove(self):
+    def remove(self) -> None:
         """
         # Summary
 
@@ -1213,8 +1202,8 @@ class SwitchOverviewSync:
             if self.sync == attribute and getattr(record, attribute) > 0:
                 setattr(record, attribute, getattr(record, attribute) - 1)
                 self.session.add(record)
+                self.session.commit()
                 break
-        self.session.commit()
 
     def response_dict(self) -> dict[str, Any]:
         """

--- a/app/v1/endpoints/lan_fabric/rest/control/switches/roles/roles_post.py
+++ b/app/v1/endpoints/lan_fabric/rest/control/switches/roles/roles_post.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel
 from sqlmodel import Session, select
 
 from ........common.enums.switch import SwitchRoleEnum, SwitchRoleFriendlyEnum
-from ........common.functions.utilities import switch_role_db_to_external, switch_role_external_to_db
+from ........common.functions.utilities import switch_role_external_to_db
 from ........db import get_session
 from .......models.inventory import SwitchDbModel
 from ...switches.models.switch_overview import SwitchOverviewRoles
@@ -57,14 +57,17 @@ def update_sw_overview_role(session: Session, fabric_name: str, current_role: st
     # Summary
 
     Update the switch roles portion of the overview table.
+
+    current_role should be in external format e.g. "border gateway", not "border_gateway".
+    new_role should be in external format e.g. "border gateway", not "border_gateway".
     """
     instance = SwitchOverviewRoles()
     instance.session = session
     instance.fabric = fabric_name
     if current_role != "":
-        instance.role = switch_role_db_to_external(current_role)
+        instance.role = current_role
         instance.remove()
-    instance.role = switch_role_db_to_external(new_role)
+    instance.role = new_role
     instance.add()
 
 

--- a/app/v1/endpoints/lan_fabric/rest/control/switches/switch_remove.py
+++ b/app/v1/endpoints/lan_fabric/rest/control/switches/switch_remove.py
@@ -1,0 +1,132 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlmodel import Session, select
+
+from .......db import get_session
+from ......models.fabric import FabricDbModelV1
+from ......models.inventory import SwitchDbModel
+from ..fabrics.common import build_404_response
+from ..switches.models.switch_overview import SwitchOverviewHealth, SwitchOverviewHw, SwitchOverviewRoles, SwitchOverviewSw, SwitchOverviewSync
+
+router = APIRouter(
+    prefix="/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics",
+)
+
+
+def update_health(db_session: Session, fabric_name: str, health: str):
+    """
+    # Summary
+
+    Update the switch health information associated with SwitchOverview.
+    """
+    if health == "":
+        return
+    instance = SwitchOverviewHealth()
+    instance.session = db_session
+    instance.fabric = fabric_name
+    instance.health = health
+    instance.remove()
+
+
+def update_hw(db_session: Session, fabric_name: str, model: str):
+    """
+    # Summary
+
+    Update the switch hardware information associated with SwitchOverview.
+    """
+    if model == "":
+        return
+    instance = SwitchOverviewHw()
+    instance.session = db_session
+    instance.fabric = fabric_name
+    instance.model = model
+    instance.remove()
+
+
+def update_role(db_session: Session, fabric_name: str, role: str):
+    """
+    # Summary
+
+    Update the switch role information associated with SwitchOverview.
+    """
+    if role == "":
+        return
+    instance = SwitchOverviewRoles()
+    instance.session = db_session
+    instance.fabric = fabric_name
+    instance.role = role
+    instance.remove()
+
+
+def update_sw(db_session: Session, fabric_name: str, release: str):
+    """
+    # Summary
+
+    Update the switch software information associated with SwitchOverview.
+    """
+    if release == "":
+        return
+    instance = SwitchOverviewSw()
+    instance.session = db_session
+    instance.fabric = fabric_name
+    instance.version = release
+    instance.remove()
+
+
+def update_sync(db_session: Session, fabric_name: str, sync: str):
+    """
+    # Summary
+
+    Update the switch sync information associated with SwitchOverview.
+    """
+    if sync == "":
+        return
+    instance = SwitchOverviewSync()
+    instance.session = db_session
+    instance.fabric = fabric_name
+    instance.sync = sync.lower().replace("-", "_")
+    instance.remove()
+
+
+description = "(v1) Remove the Switch from the given Fabric."
+
+
+@router.delete("/{fabric_name}/switches/{serial_number}", description=description)
+def v1_remove_switch_from_fabric(*, session: Session = Depends(get_session), fabric_name: str, serial_number: str):
+    """
+    # Summary
+
+    Switch DELETE request handler
+
+    ## Path
+
+    /appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{fabricName}/switches/{serialNumber}
+    """
+    db_fabric = session.exec(select(FabricDbModelV1).where(FabricDbModelV1.FABRIC_NAME == fabric_name)).first()
+    if not db_fabric:
+        path = f"{router.prefix}/{fabric_name}/switches/{serial_number}"
+        raise HTTPException(status_code=404, detail=build_404_response(path))
+    fabric_id = db_fabric.id
+    db_switch = session.exec(select(SwitchDbModel).where(SwitchDbModel.fabricId == fabric_id).where(SwitchDbModel.serialNumber == serial_number)).first()
+    if db_switch is None:
+        # NDFC returns 200 as if the switch was actually removed.  We emulate that here.
+        msg = f"The switch(es)={serial_number} have been removed from the fabric={fabric_name}"
+        return msg
+
+    health = db_switch.operStatus
+    model = db_switch.model
+    release = db_switch.release
+    role = db_switch.switchRole
+    sync = db_switch.ccStatus
+
+    update_health(session, fabric_name, health)
+    update_hw(session, fabric_name, model)
+    update_role(session, fabric_name, role)
+    update_sw(session, fabric_name, release)
+    update_sync(session, fabric_name, sync)
+
+    session.delete(db_switch)
+    session.commit()
+    # NDFC response
+    # The switch(es)=FOX2109PGCS have been removed from the fabric=F1
+    msg = f"The switch(es)={serial_number} have been removed from the fabric={fabric_name}"
+    return msg

--- a/docs/supported_endpoints.md
+++ b/docs/supported_endpoints.md
@@ -132,6 +132,10 @@
   - `get`
     - V1 Switches Overview Get
 
+- `/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{fabric_name}/switches/{serial_number}`
+  - `delete`
+    - V1 Remove Switch From Fabric
+
 ## Templates (v1)
 
 - `/appcenter/cisco/ndfc/api/v1/configtemplate/rest/config/templates/{template_name}`


### PR DESCRIPTION
# New endpoint handler

Add endpoint handler for:

`/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{fabricName}/switches/{serialNumber}`

### 1. app/main.py

- Update imports
- app.include_router(switch_remove.router, tags=["Switches (v1)"])

### 2. app/v1/endpoints/lan_fabric/rest/control/switches/models/switch_overview.py

- Add type hints for all method return values
- All methods: Call self.session.commit(), call only if needed.
- SwitchOverviewRoles(): remove unused vars

### 3. app/v1/endpoints/lan_fabric/rest/control/switches/roles/roles_post.py

- update_sw_overview_role().  Remove call to switch_role_db_to_external() since we expect current_role and new_role already to be in external role format.


### 4. app/v1/endpoints/lan_fabric/rest/control/switches/switch_remove.py

New endpoint handler to remove switch from a fabric.

### 5. docs/supported_endpoints.md

Add new endpoint

### 6. app/v1/endpoints/lan_fabric/rest/control/fabrics/inventory/discover_post.py

## discover_post.py

For now, let's update a switch's parameters that have to do with status, to match what we are storing in the overview table.  This way, we can reference the switch params when updating the overview table.  This isn't NDFC behavior, but may be good enough, at least for now.  We can revisit later.

Another approach, which we'll look into, would be to ignore ccStatus, operStatus, switchRole, etc, when updating the overview table if these are null ("") in the switch record.

### 1. app/v1/endpoints/lan_fabric/rest/control/fabrics/inventory/discover_post.py

- On POST, update switch parameters to match what is stored in the overview tables.