### PR TITLE
Update switch_remove documentation documentation

### DIFF
--- a/docs/supported_endpoints.md
+++ b/docs/supported_endpoints.md
@@ -132,9 +132,9 @@
   - `get`
     - V1 Switches Overview Get
 
-- `/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{fabric_name}/switches/{serial_number}`
+- `/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/{fabricName}/switches/{serialNumbers}`
   - `delete`
-    - V1 Remove Switch From Fabric
+    - (v1) Remove the switch(es), specified by serialNumbers, a comma-separated list of switch serial numbers, from the fabric specified by fabricName.
 
 ## Templates (v1)
 


### PR DESCRIPTION
1. app/v1/endpoints/lan_fabric/rest/control/switches/switch_remove.py

- Update description var
- Specify summary=description in path property
- Rename fabric_name to fabricName and user_serial_numbers to serialNumbers
- Remove commented code